### PR TITLE
CNF-22151: Add validating admission webhooks for PowerNodeConfig, Uncore, and PowerProfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,11 +233,21 @@ undeploy:
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 ifeq (false, $(OCP))
-	sed -i 's/- .*\/rbac\.yaml/- \.\/rbac.yaml/' config/rbac/kustomization.yaml
-	sed -i 's/- .*\/role\.yaml/- \.\/role.yaml/' config/rbac/kustomization.yaml
+	sed -i 's|- .*\/rbac\.yaml|- \.\/rbac.yaml|' config/rbac/kustomization.yaml
+	sed -i 's|- .*\/role\.yaml|- \.\/role.yaml|' config/rbac/kustomization.yaml
+	sed -i 's|- \.\./manager/ocp$$|- ../manager|' config/default/kustomization.yaml
+	sed -i '\|- \.\./certmanager$$|d' config/default/kustomization.yaml
+	sed -i '\|- \.\./webhook$$|a\- ../certmanager' config/default/kustomization.yaml
+	sed -i 's|- path: ocp/webhookcainjection_patch\.yaml$$|- path: webhookcainjection_patch.yaml|' config/default/kustomization.yaml
+	sed -i '\|- path: certmanager_replacements\.yaml$$|d' config/default/kustomization.yaml
+	sed -i '\|replacements:$$|a\- path: certmanager_replacements.yaml' config/default/kustomization.yaml
 else
-	sed -i 's/- .*\/rbac\.yaml/- \.\/ocp\/rbac.yaml/' config/rbac/kustomization.yaml
-	sed -i 's/- .*\/role\.yaml/- \.\/ocp\/role.yaml/' config/rbac/kustomization.yaml
+	sed -i 's|- .*\/rbac\.yaml|- \.\/ocp\/rbac.yaml|' config/rbac/kustomization.yaml
+	sed -i 's|- .*\/role\.yaml|- \.\/ocp\/role.yaml|' config/rbac/kustomization.yaml
+	sed -i 's|- \.\./manager$$|- ../manager/ocp|' config/default/kustomization.yaml
+	sed -i '\|- \.\./certmanager$$|d' config/default/kustomization.yaml
+	sed -i 's|- path: webhookcainjection_patch\.yaml$$|- path: ocp/webhookcainjection_patch.yaml|' config/default/kustomization.yaml
+	sed -i '\|- path: certmanager_replacements\.yaml$$|d' config/default/kustomization.yaml
 endif
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
@@ -356,11 +366,6 @@ push:
 # Generate bundle manifests and metadata, then validate generated files.
 bundle: update manifests kustomize operator-sdk
 # directory used to get image name for bundle
-ifeq (false, $(OCP))
-	sed -i 's|^\- \.\./manager/ocp$$|- ../manager|' config/default/kustomization.yaml
-else
-	sed -i 's|^\- \.\./manager$$|- ../manager/ocp|' config/default/kustomization.yaml
-endif
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --use-image-digests --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS)

--- a/api/v1/powernodeconfig_webhook.go
+++ b/api/v1/powernodeconfig_webhook.go
@@ -1,0 +1,69 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:path=/validate-power-openshift-io-v1-powernodeconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=power.openshift.io,resources=powernodeconfigs,verbs=create;update,versions=v1,name=vpowernodeconfig.kb.io,admissionReviewVersions=v1
+
+var powernodeconfiglog = logf.Log.WithName("powernodeconfig-webhook")
+
+// powerNodeConfigValidator implements admission.CustomValidator for PowerNodeConfig.
+type powerNodeConfigValidator struct{}
+
+// SetupPowerNodeConfigWebhookWithManager registers the validating webhook for PowerNodeConfig.
+func SetupPowerNodeConfigWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&PowerNodeConfig{}).
+		WithValidator(&powerNodeConfigValidator{}).
+		Complete()
+}
+
+var _ webhook.CustomValidator = &powerNodeConfigValidator{}
+
+// ValidateCreate implements admission.CustomValidator.
+func (v *powerNodeConfigValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	config, ok := obj.(*PowerNodeConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected PowerNodeConfig, got %T", obj)
+	}
+	powernodeconfiglog.Info("validating create", "name", config.Name)
+	return nil, nil
+}
+
+// ValidateUpdate implements admission.CustomValidator.
+func (v *powerNodeConfigValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	config, ok := newObj.(*PowerNodeConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected PowerNodeConfig, got %T", newObj)
+	}
+	powernodeconfiglog.Info("validating update", "name", config.Name)
+	return nil, nil
+}
+
+// ValidateDelete implements admission.CustomValidator.
+func (v *powerNodeConfigValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/api/v1/powerprofile_webhook.go
+++ b/api/v1/powerprofile_webhook.go
@@ -1,0 +1,64 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:path=/validate-power-openshift-io-v1-powerprofile,mutating=false,failurePolicy=fail,sideEffects=None,groups=power.openshift.io,resources=powerprofiles,verbs=delete,versions=v1,name=vpowerprofile.kb.io,admissionReviewVersions=v1
+
+var powerprofilelog = logf.Log.WithName("powerprofile-webhook")
+
+// powerProfileValidator implements admission.CustomValidator for PowerProfile.
+type powerProfileValidator struct{}
+
+// SetupPowerProfileWebhookWithManager registers the validating webhook for PowerProfile.
+func SetupPowerProfileWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&PowerProfile{}).
+		WithValidator(&powerProfileValidator{}).
+		Complete()
+}
+
+var _ webhook.CustomValidator = &powerProfileValidator{}
+
+// ValidateCreate implements admission.CustomValidator.
+func (v *powerProfileValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// ValidateUpdate implements admission.CustomValidator.
+func (v *powerProfileValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// ValidateDelete implements admission.CustomValidator.
+func (v *powerProfileValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	profile, ok := obj.(*PowerProfile)
+	if !ok {
+		return nil, fmt.Errorf("expected PowerProfile, got %T", obj)
+	}
+	powerprofilelog.Info("validating delete", "name", profile.Name)
+	return nil, nil
+}

--- a/api/v1/uncore_webhook.go
+++ b/api/v1/uncore_webhook.go
@@ -1,0 +1,69 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:path=/validate-power-openshift-io-v1-uncore,mutating=false,failurePolicy=fail,sideEffects=None,groups=power.openshift.io,resources=uncores,verbs=create;update,versions=v1,name=vuncore.kb.io,admissionReviewVersions=v1
+
+var uncorelog = logf.Log.WithName("uncore-webhook")
+
+// uncoreValidator implements admission.CustomValidator for Uncore.
+type uncoreValidator struct{}
+
+// SetupUncoreWebhookWithManager registers the validating webhook for Uncore.
+func SetupUncoreWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&Uncore{}).
+		WithValidator(&uncoreValidator{}).
+		Complete()
+}
+
+var _ webhook.CustomValidator = &uncoreValidator{}
+
+// ValidateCreate implements admission.CustomValidator.
+func (v *uncoreValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	uncore, ok := obj.(*Uncore)
+	if !ok {
+		return nil, fmt.Errorf("expected Uncore, got %T", obj)
+	}
+	uncorelog.Info("validating create", "name", uncore.Name)
+	return nil, nil
+}
+
+// ValidateUpdate implements admission.CustomValidator.
+func (v *uncoreValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	uncore, ok := newObj.(*Uncore)
+	if !ok {
+		return nil, fmt.Errorf("expected Uncore, got %T", newObj)
+	}
+	uncorelog.Info("validating update", "name", uncore.Name)
+	return nil, nil
+}
+
+// ValidateDelete implements admission.CustomValidator.
+func (v *uncoreValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/build/manager/main.go
+++ b/build/manager/main.go
@@ -29,6 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	powerv1 "github.com/openshift-kni/kubernetes-power-manager/api/v1"
 
@@ -52,10 +53,15 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var enableWebhooks bool
+	var webhookCertDir string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&enableWebhooks, "enable-webhooks", true, "Enable admission webhooks.")
+	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs",
+		"Directory containing TLS certs (tls.crt, tls.key) for the webhook server.")
 
 	logOpts := zap.Options{}
 	logOpts.BindFlags(flag.CommandLine)
@@ -71,14 +77,23 @@ func main() {
 	)
 	renewDeadline := time.Second * time.Duration(20)
 	leaseDuration := time.Second * time.Duration(30)
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOpts := ctrl.Options{
 		Scheme:           scheme,
 		Metrics:          server.Options{BindAddress: metricsAddr},
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: "power-operator-6846766c",
 		RenewDeadline:    &renewDeadline,
 		LeaseDuration:    &leaseDuration,
-	})
+	}
+
+	if enableWebhooks {
+		mgrOpts.WebhookServer = webhook.NewServer(webhook.Options{
+			Port:    9443,
+			CertDir: webhookCertDir,
+		})
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
@@ -96,6 +111,21 @@ func main() {
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder
+
+	if enableWebhooks {
+		if err = powerv1.SetupPowerNodeConfigWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "PowerNodeConfig")
+			os.Exit(1)
+		}
+		if err = powerv1.SetupUncoreWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "Uncore")
+			os.Exit(1)
+		}
+		if err = powerv1.SetupPowerProfileWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "PowerProfile")
+			os.Exit(1)
+		}
+	}
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/bundle/manifests/kubernetes-power-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-power-manager.clusterserviceversion.yaml
@@ -248,6 +248,10 @@ spec:
                     image: quay.io/openshift-kni/kubernetes-power-manager-operator:0.0.1
                     imagePullPolicy: IfNotPresent
                     name: manager
+                    ports:
+                      - containerPort: 9443
+                        name: webhook-server
+                        protocol: TCP
                     resources:
                       limits:
                         cpu: 100m
@@ -265,6 +269,9 @@ spec:
                       seccompProfile:
                         type: RuntimeDefault
                     volumeMounts:
+                      - mountPath: /tmp/k8s-webhook-server/serving-certs
+                        name: cert
+                        readOnly: true
                       - mountPath: /sys/fs/cgroup
                         mountPropagation: HostToContainer
                         name: cgroup
@@ -272,6 +279,10 @@ spec:
                 serviceAccountName: power-manager-operator
                 terminationGracePeriodSeconds: 10
                 volumes:
+                  - name: cert
+                    secret:
+                      defaultMode: 420
+                      secretName: webhook-server-cert
                   - hostPath:
                       path: /sys/fs/cgroup
                     name: cgroup
@@ -332,3 +343,63 @@ spec:
     - image: quay.io/openshift-kni/kubernetes-power-manager-operator:0.0.1
       name: manager
   version: 0.0.1
+  webhookdefinitions:
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: controller-manager
+      failurePolicy: Fail
+      generateName: vpowernodeconfig.kb.io
+      rules:
+        - apiGroups:
+            - power.openshift.io
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - powernodeconfigs
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-power-openshift-io-v1-powernodeconfig
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: controller-manager
+      failurePolicy: Fail
+      generateName: vpowerprofile.kb.io
+      rules:
+        - apiGroups:
+            - power.openshift.io
+          apiVersions:
+            - v1
+          operations:
+            - DELETE
+          resources:
+            - powerprofiles
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-power-openshift-io-v1-powerprofile
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: controller-manager
+      failurePolicy: Fail
+      generateName: vuncore.kb.io
+      rules:
+        - apiGroups:
+            - power.openshift.io
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - uncores
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-power-openshift-io-v1-uncore

--- a/bundle/manifests/power-manager-webhook-service_v1_service.yaml
+++ b/bundle/manifests/power-manager-webhook-service_v1_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
+  creationTimestamp: null
+  name: power-manager-webhook-service
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -2,25 +2,28 @@
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
 # breaking changes
-apiVersion: cert-manager.io/v1alpha2
+# Used for vanilla K8s deployments with cert-manager.
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
   namespace: system
 spec:
-  selfSigned: { }
+  selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
+  privateKey:
+    rotationPolicy: Always
   secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution 
+# This configuration is for teaching kustomize how to update name ref substitution
 nameReference:
   - kind: Issuer
     group: cert-manager.io
@@ -6,11 +6,3 @@ nameReference:
       - kind: Certificate
         group: cert-manager.io
         path: spec/issuerRef/name
-
-varReference:
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/commonName
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/dnsNames

--- a/config/default/certmanager_replacements.yaml
+++ b/config/default/certmanager_replacements.yaml
@@ -1,0 +1,66 @@
+# Replacements for cert-manager webhook certificate DNS names and CA injection.
+# These substitute the webhook Service name and namespace into the Certificate
+# dnsNames and the ValidatingWebhookConfiguration CA injection annotation.
+- source:
+    kind: Service
+    version: v1
+    name: power-manager-webhook-service
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: cert-manager.io
+      kind: Certificate
+      name: serving-cert
+    fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 0
+- source:
+    kind: Service
+    version: v1
+    name: power-manager-webhook-service
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      group: cert-manager.io
+      kind: Certificate
+      name: serving-cert
+    fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 1
+- source:
+    kind: Service
+    version: v1
+    name: power-manager-webhook-service
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: power-manager-validating-webhook-configuration
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+    fieldPath: metadata.name
+  targets:
+  - select:
+      group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: power-manager-validating-webhook-configuration
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -17,3 +17,17 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../webhook
+- ../certmanager
+
+patches:
+- path: manager_webhook_patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: controller-manager
+- path: webhookcainjection_patch.yaml
+
+replacements:
+- path: certmanager_replacements.yaml

--- a/config/default/ocp/webhookcainjection_patch.yaml
+++ b/config/default/ocp/webhookcainjection_patch.yaml
@@ -1,0 +1,16 @@
+# Enable OpenShift service-ca to inject the CA bundle into the webhook configuration.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: power-manager-validating-webhook-configuration
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+---
+# Request OpenShift service-ca to generate a serving certificate for the webhook service.
+apiVersion: v1
+kind: Service
+metadata:
+  name: power-manager-webhook-service
+  namespace: system
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,15 +1,15 @@
 # This patch add annotation to admission webhook config and
-# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: mutating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+# the variables CERTIFICATE_NAMESPACE and CERTIFICATE_NAME will be substituted by kustomize.
+# apiVersion: admissionregistration.k8s.io/v1beta1
+# kind: MutatingWebhookConfiguration
+# metadata:
+#   name: mutating-webhook-configuration
+#   annotations:
+#     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-webhook-configuration
+  name: power-manager-validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/config/manager/ocp/manager.yaml
+++ b/config/manager/ocp/manager.yaml
@@ -1,3 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: power-operator
+    app.kubernetes.io/component: power-operator
+    control-plane: controller-manager
+  name: power-manager
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,3 +1,5 @@
+namePrefix: power-manager-
+
 resources:
   - manifests.yaml
   - service.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -4,18 +4,18 @@ nameReference:
   - kind: Service
     version: v1
     fieldSpecs:
-      - kind: MutatingWebhookConfiguration
-        group: admissionregistration.k8s.io
-        path: webhooks/clientConfig/service/name
+      #- kind: MutatingWebhookConfiguration
+      #  group: admissionregistration.k8s.io
+      #  path: webhooks/clientConfig/service/name
       - kind: ValidatingWebhookConfiguration
         group: admissionregistration.k8s.io
         path: webhooks/clientConfig/service/name
 
 namespace:
-  - kind: MutatingWebhookConfiguration
-    group: admissionregistration.k8s.io
-    path: webhooks/clientConfig/service/namespace
-    create: true
+  #- kind: MutatingWebhookConfiguration
+  #  group: admissionregistration.k8s.io
+  #  path: webhooks/clientConfig/service/namespace
+  #  create: true
   - kind: ValidatingWebhookConfiguration
     group: admissionregistration.k8s.io
     path: webhooks/clientConfig/service/namespace

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-power-openshift-io-v1-powernodeconfig
+  failurePolicy: Fail
+  name: vpowernodeconfig.kb.io
+  rules:
+  - apiGroups:
+    - power.openshift.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - powernodeconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-power-openshift-io-v1-powerprofile
+  failurePolicy: Fail
+  name: vpowerprofile.kb.io
+  rules:
+  - apiGroups:
+    - power.openshift.io
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - powerprofiles
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-power-openshift-io-v1-uncore
+  failurePolicy: Fail
+  name: vuncore.kb.io
+  rules:
+  - apiGroups:
+    - power.openshift.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - uncores
+  sideEffects: None


### PR DESCRIPTION
Set up the webhook infrastructure for PowerNodeConfig (create/update), Uncore (create/update), and PowerProfile (delete) with stub handlers that log requests. Validation logic will be added in a follow-up commit.

Certificate management per deployment method:
- make deploy (K8s): cert-manager
- OCP=true make deploy (OpenShift): service-ca
- OCP=true make bundle (OLM): OLM-managed certs

All three deployment methods have been tested and verified.

The manager binary accepts --enable-webhooks (default true) and --webhook-cert-dir flags for flexible deployment and local development.