### PR TITLE
Remove redundant spec.name from PowerProfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,6 @@ kind: PowerProfile
 metadata:
   name: performance-example-application
 spec:
-  name: "performance-example-application"
   cpuCapacity: "75%"
   nodeSelector:
     labelSelector:
@@ -489,7 +488,6 @@ kind: PowerProfile
 metadata:
   name: shared-example-node1
 spec:
-  name: "shared-example-node1"
   shared: true
   pstates:
     max: 1500
@@ -504,7 +502,6 @@ kind: PowerProfile
 metadata:
   name: shared-example-node2
 spec:
-  name: "shared-example-node2"
   cpuCapacity: "75%"
   nodeSelector:
     labelSelector:

--- a/api/v1/powerprofile_types.go
+++ b/api/v1/powerprofile_types.go
@@ -27,9 +27,6 @@ import (
 type PowerProfileSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// The name of the PowerProfile
-	Name string `json:"name"`
-
 	Shared bool `json:"shared,omitempty"`
 
 	// NodeSelector specifies which nodes this PowerProfile should be applied to

--- a/bundle/manifests/kubernetes-power-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-power-manager.clusterserviceversion.yaml
@@ -71,7 +71,6 @@ metadata:
             "cstates": {
               "maxLatencyUs": 1
             },
-            "name": "shared",
             "pstates": {
               "epp": "power",
               "governor": "powersave",

--- a/bundle/manifests/power.openshift.io_powerprofiles.yaml
+++ b/bundle/manifests/power.openshift.io_powerprofiles.yaml
@@ -139,9 +139,6 @@ spec:
                 - message: Specify either 'names' or 'maxLatencyUs' for C-state configuration,
                     but not both
                   rule: '!(has(self.names) && has(self.maxLatencyUs))'
-              name:
-                description: The name of the PowerProfile
-                type: string
               nodeSelector:
                 description: |-
                   NodeSelector specifies which nodes this PowerProfile should be applied to
@@ -227,8 +224,6 @@ spec:
                 type: object
               shared:
                 type: boolean
-            required:
-            - name
             type: object
             x-kubernetes-validations:
             - message: pstates.governor must be 'userspace' when cpuScalingPolicy

--- a/config/crd/bases/power.openshift.io_powerprofiles.yaml
+++ b/config/crd/bases/power.openshift.io_powerprofiles.yaml
@@ -139,9 +139,6 @@ spec:
                 - message: Specify either 'names' or 'maxLatencyUs' for C-state configuration,
                     but not both
                   rule: '!(has(self.names) && has(self.maxLatencyUs))'
-              name:
-                description: The name of the PowerProfile
-                type: string
               nodeSelector:
                 description: |-
                   NodeSelector specifies which nodes this PowerProfile should be applied to
@@ -227,8 +224,6 @@ spec:
                 type: object
               shared:
                 type: boolean
-            required:
-            - name
             type: object
             x-kubernetes-validations:
             - message: pstates.governor must be 'userspace' when cpuScalingPolicy

--- a/config/samples/power_v1_shared_profile.yaml
+++ b/config/samples/power_v1_shared_profile.yaml
@@ -10,7 +10,6 @@ metadata:
   name: shared
   namespace: power-manager
 spec:
-  name: "shared"
   shared: true
   pstates:
     max: 1000

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -91,11 +91,11 @@ func isValidEpp(inputName string) bool {
 
 // doesNodeMatchPowerProfileSelector checks if a PowerProfile should be applied to a specific node.
 func doesNodeMatchPowerProfileSelector(c client.Client, profile *powerv1.PowerProfile, nodeName string, logger *logr.Logger) (bool, error) {
-	logger.V(5).Info("Checking if PowerProfile should be applied to node", "profile", profile.Spec.Name, "nodeName", nodeName)
+	logger.V(5).Info("Checking if PowerProfile should be applied to node", "profile", profile.Name, "nodeName", nodeName)
 	// If no label selector is specified, apply to all nodes.
 	labelSelector := profile.Spec.NodeSelector.LabelSelector
 	if len(labelSelector.MatchLabels) == 0 && len(labelSelector.MatchExpressions) == 0 {
-		logger.V(5).Info("No label selector specified, applying PowerProfile to all nodes", "profile", profile.Spec.Name, "nodeName", nodeName)
+		logger.V(5).Info("No label selector specified, applying PowerProfile to all nodes", "profile", profile.Name, "nodeName", nodeName)
 		return true, nil
 	}
 
@@ -239,8 +239,8 @@ func addPowerNodeStatusProfileEntry(ctx context.Context, c client.Client, nodeNa
 	}
 
 	errList := util.UnpackErrsToStrings(profileErrors)
-	profileStatus := powerv1.PowerNodeProfileStatus{Name: profile.Spec.Name, Config: config, Errors: *errList}
-	fieldManager := powerProfileFieldManager(profile.Spec.Name)
+	profileStatus := powerv1.PowerNodeProfileStatus{Name: profile.Name, Config: config, Errors: *errList}
+	fieldManager := powerProfileFieldManager(profile.Name)
 
 	err = applyPowerNodeStateProfilesStatus(ctx, c, powerNodeStateName, []powerv1.PowerNodeProfileStatus{profileStatus}, fieldManager)
 	if err != nil {
@@ -255,7 +255,7 @@ func addPowerNodeStatusProfileEntry(ctx context.Context, c client.Client, nodeNa
 
 	logger.Info("Updated PowerNodeState with profile validation results",
 		"powerNodeState", powerNodeStateName,
-		"profile", profile.Spec.Name,
+		"profile", profile.Name,
 		"errors", len(*errList))
 
 	return nil

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -89,7 +89,6 @@ func Test_addPowerNodeStatusProfileEntry(t *testing.T) {
 			Namespace: PowerNamespace,
 		},
 		Spec: powerv1.PowerProfileSpec{
-			Name: "test-profile",
 			PStates: powerv1.PStatesConfig{
 				Min:      intStrFromInt(2000),
 				Max:      intStrFromInt(3000),
@@ -204,7 +203,6 @@ func Test_addPowerNodeStatusProfileEntry(t *testing.T) {
 					Namespace: PowerNamespace,
 				},
 				Spec: powerv1.PowerProfileSpec{
-					Name: "dpdk-profile",
 					PStates: powerv1.PStatesConfig{
 						Min:      intStrFromInt(2000),
 						Max:      intStrFromInt(3000),

--- a/controllers/envtest_common.go
+++ b/controllers/envtest_common.go
@@ -79,7 +79,7 @@ func createTestPowerNodeState(t *testing.T, cl client.Client, name string) {
 func newTestPowerProfile(name string, shared bool) *powerv1.PowerProfile {
 	return &powerv1.PowerProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: PowerNamespace},
-		Spec:       powerv1.PowerProfileSpec{Name: name, Shared: shared},
+		Spec:       powerv1.PowerProfileSpec{Shared: shared},
 	}
 }
 

--- a/controllers/envtest_powerpod_controller_test.go
+++ b/controllers/envtest_powerpod_controller_test.go
@@ -96,7 +96,7 @@ func createPodReconcilePrereqs(t *testing.T, cl client.Client, ctx context.Conte
 	for _, name := range profileNames {
 		require.NoError(t, cl.Create(ctx, &powerv1.PowerProfile{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: PowerNamespace},
-			Spec:       powerv1.PowerProfileSpec{Name: name},
+			Spec:       powerv1.PowerProfileSpec{},
 		}))
 	}
 }

--- a/controllers/powerconfig_controller_test.go
+++ b/controllers/powerconfig_controller_test.go
@@ -166,7 +166,6 @@ func TestPowerConfig_Reconcile_Deletion(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},

--- a/controllers/powernodeconfig_controller_test.go
+++ b/controllers/powernodeconfig_controller_test.go
@@ -291,8 +291,8 @@ func TestValidatePowerNodeConfigProfiles(t *testing.T) {
 			config: newPowerNodeConfig("c", "shared-prof", nil, []powerv1.ReservedSpec{{Cores: []uint{0}, PowerProfile: "reserved-prof"}}, time.Now()),
 			clientObjs: []runtime.Object{
 				newTestNode("test-node", map[string]string{}),
-				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "shared-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Name: "shared-prof", Shared: true}},
-				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "reserved-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Name: "reserved-prof"}},
+				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "shared-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Shared: true}},
+				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "reserved-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{}},
 			},
 			setupMock: func() *hostMock {
 				h := new(hostMock)
@@ -306,7 +306,7 @@ func TestValidatePowerNodeConfigProfiles(t *testing.T) {
 			config: newPowerNodeConfig("c", "not-shared", nil, nil, time.Now()),
 			clientObjs: []runtime.Object{
 				newTestNode("test-node", map[string]string{}),
-				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "not-shared", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Name: "not-shared", Shared: false}},
+				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "not-shared", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Shared: false}},
 			},
 			setupMock: func() *hostMock {
 				return new(hostMock)
@@ -319,7 +319,7 @@ func TestValidatePowerNodeConfigProfiles(t *testing.T) {
 			config: newPowerNodeConfig("c", "missing", nil, nil, time.Now()),
 			clientObjs: []runtime.Object{
 				newTestNode("test-node", map[string]string{}),
-				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Name: "missing", Shared: true}},
+				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Shared: true}},
 			},
 			setupMock: func() *hostMock {
 				h := new(hostMock)
@@ -337,7 +337,7 @@ func TestValidatePowerNodeConfigProfiles(t *testing.T) {
 			}, time.Now()),
 			clientObjs: []runtime.Object{
 				newTestNode("test-node", map[string]string{}),
-				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "shared-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Name: "shared-prof", Shared: true}},
+				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "shared-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Shared: true}},
 			},
 			setupMock: func() *hostMock {
 				return new(hostMock)
@@ -353,7 +353,7 @@ func TestValidatePowerNodeConfigProfiles(t *testing.T) {
 			}, time.Now()),
 			clientObjs: []runtime.Object{
 				newTestNode("test-node", map[string]string{}),
-				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "shared-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Name: "shared-prof", Shared: true}},
+				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "shared-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Shared: true}},
 			},
 			setupMock: func() *hostMock {
 				return new(hostMock)
@@ -366,8 +366,8 @@ func TestValidatePowerNodeConfigProfiles(t *testing.T) {
 			config: newPowerNodeConfig("c", "shared-prof", nil, []powerv1.ReservedSpec{{Cores: []uint{0}, PowerProfile: "missing"}}, time.Now()),
 			clientObjs: []runtime.Object{
 				newTestNode("test-node", map[string]string{}),
-				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "shared-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Name: "shared-prof", Shared: true}},
-				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Name: "missing"}},
+				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "shared-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Shared: true}},
+				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{}},
 			},
 			setupMock: func() *hostMock {
 				h := new(hostMock)
@@ -764,7 +764,7 @@ func TestApplyPowerNodeConfig(t *testing.T) {
 			clientObjs: []runtime.Object{
 				newTestNode("test-node", map[string]string{}),
 				newPowerNodeState("test-node", ""),
-				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "missing-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Name: "missing-prof"}},
+				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "missing-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{}},
 			},
 			setupMock: func() *hostMock {
 				h := new(hostMock)
@@ -779,7 +779,7 @@ func TestApplyPowerNodeConfig(t *testing.T) {
 			clientObjs: []runtime.Object{
 				newTestNode("test-node", map[string]string{}),
 				newPowerNodeState("test-node", ""),
-				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "test-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Name: "test-prof", Shared: true}},
+				&powerv1.PowerProfile{ObjectMeta: metav1.ObjectMeta{Name: "test-prof", Namespace: PowerNamespace}, Spec: powerv1.PowerProfileSpec{Shared: true}},
 			},
 			setupMock: func() *hostMock {
 				h := new(hostMock)

--- a/controllers/powerpod_controller_test.go
+++ b/controllers/powerpod_controller_test.go
@@ -160,9 +160,7 @@ var defaultProfile = &powerv1.PowerProfile{
 		Name:      "performance",
 		Namespace: PowerNamespace,
 	},
-	Spec: powerv1.PowerProfileSpec{
-		Name: "performance",
-	},
+	Spec: powerv1.PowerProfileSpec{},
 }
 
 var defaultPowerNodeState = &powerv1.PowerNodeState{
@@ -340,9 +338,7 @@ func TestPowerPod_Reconcile_Create(t *testing.T) {
 						Name:      "balance-performance",
 						Namespace: PowerNamespace,
 					},
-					Spec: powerv1.PowerProfileSpec{
-						Name: "balance-performance",
-					},
+					Spec: powerv1.PowerProfileSpec{},
 				},
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -667,9 +663,7 @@ func TestPowerPod_Reconcile_ControllerErrors(t *testing.T) {
 						Name:      "balance-performance",
 						Namespace: PowerNamespace,
 					},
-					Spec: powerv1.PowerProfileSpec{
-						Name: "balance-performance",
-					},
+					Spec: powerv1.PowerProfileSpec{},
 				},
 
 				&corev1.Pod{
@@ -1375,7 +1369,6 @@ func TestPowerPod_ValidateProfileNodeSelectorMatching(t *testing.T) {
 			Namespace: PowerNamespace,
 		},
 		Spec: powerv1.PowerProfileSpec{
-			Name: "performance",
 			NodeSelector: powerv1.NodeSelector{
 				LabelSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -1392,7 +1385,6 @@ func TestPowerPod_ValidateProfileNodeSelectorMatching(t *testing.T) {
 			Namespace: PowerNamespace,
 		},
 		Spec: powerv1.PowerProfileSpec{
-			Name: "gpu-optimized",
 			NodeSelector: powerv1.NodeSelector{
 				LabelSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -1408,10 +1400,7 @@ func TestPowerPod_ValidateProfileNodeSelectorMatching(t *testing.T) {
 			Name:      "universal",
 			Namespace: PowerNamespace,
 		},
-		Spec: powerv1.PowerProfileSpec{
-			Name: "universal",
-			// No node selector - should apply to all nodes
-		},
+		Spec: powerv1.PowerProfileSpec{},
 	}
 
 	expressionMatchingProfile := &powerv1.PowerProfile{
@@ -1420,7 +1409,6 @@ func TestPowerPod_ValidateProfileNodeSelectorMatching(t *testing.T) {
 			Namespace: PowerNamespace,
 		},
 		Spec: powerv1.PowerProfileSpec{
-			Name: "zone-specific",
 			NodeSelector: powerv1.NodeSelector{
 				LabelSelector: metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -1778,7 +1766,6 @@ func TestPowerPod_ValidateProfileNodeSelectorMatching(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "nonexistent",
 						NodeSelector: powerv1.NodeSelector{
 							LabelSelector: metav1.LabelSelector{
 								MatchLabels: map[string]string{
@@ -2410,7 +2397,7 @@ func TestPowerPod_Reconcile_WithCpuScalingPolicy(t *testing.T) {
 			}
 			profile := &powerv1.PowerProfile{
 				ObjectMeta: metav1.ObjectMeta{Name: tc.profileName, Namespace: PowerNamespace},
-				Spec:       powerv1.PowerProfileSpec{Name: tc.profileName, CpuScalingPolicy: policy},
+				Spec:       powerv1.PowerProfileSpec{CpuScalingPolicy: policy},
 			}
 
 			// Build resource requirements referencing the profile.
@@ -2551,7 +2538,7 @@ func TestPowerPod_Reconcile_MultipleDPDKContainersRejected(t *testing.T) {
 	}
 	profile := &powerv1.PowerProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profileName, Namespace: PowerNamespace},
-		Spec:       powerv1.PowerProfileSpec{Name: profileName, CpuScalingPolicy: policy},
+		Spec:       powerv1.PowerProfileSpec{CpuScalingPolicy: policy},
 	}
 
 	// Both containers request the same DPDK profile.

--- a/controllers/powerprofile_controller.go
+++ b/controllers/powerprofile_controller.go
@@ -204,7 +204,7 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Create and validate power profile in the power library
 	powerProfile, err := power.NewPowerProfile(
-		profile.Spec.Name, profile.Spec.PStates.Min, profile.Spec.PStates.Max,
+		profile.Name, profile.Spec.PStates.Min, profile.Spec.PStates.Max,
 		profile.Spec.PStates.Governor, actualEpp,
 		profile.Spec.CStates.Names, profile.Spec.CStates.MaxLatencyUs)
 	if err != nil {
@@ -212,24 +212,24 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 	// An exclusive pool should be created for both shared and non-shared profiles.
-	profileFromLibrary := r.PowerLibrary.GetExclusivePool(profile.Spec.Name)
+	profileFromLibrary := r.PowerLibrary.GetExclusivePool(profile.Name)
 	if profileFromLibrary == nil {
-		pool, err := r.PowerLibrary.AddExclusivePool(profile.Spec.Name)
+		pool, err := r.PowerLibrary.AddExclusivePool(profile.Name)
 		if err != nil {
 			logger.Error(err, "failed to create the power profile")
 			return ctrl.Result{}, err
 		}
 		err = pool.SetPowerProfile(powerProfile)
 		if err != nil {
-			logger.Error(err, fmt.Sprintf("error adding the profile '%s' to the power library for host '%s'", profile.Spec.Name, nodeName))
+			logger.Error(err, fmt.Sprintf("error adding the profile '%s' to the power library for host '%s'", profile.Name, nodeName))
 			return ctrl.Result{}, err
 		}
 
-		logger.V(5).Info("power profile successfully created", "profile", profile.Spec.Name)
+		logger.V(5).Info("power profile successfully created", "profile", profile.Name)
 	} else {
 		// Exclusive pool for this profile already exists, update it and all the other pools that use this profile
-		err = r.PowerLibrary.GetExclusivePool(profile.Spec.Name).SetPowerProfile(powerProfile)
-		msg := fmt.Sprintf("updating the power profile '%s' to the power library for node '%s'", profile.Spec.Name, nodeName)
+		err = r.PowerLibrary.GetExclusivePool(profile.Name).SetPowerProfile(powerProfile)
+		msg := fmt.Sprintf("updating the power profile '%s' to the power library for node '%s'", profile.Name, nodeName)
 		logger.V(5).Info(msg)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("error %s: %v", msg, err)
@@ -237,8 +237,8 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 		// Update shared pool if it uses this profile
 		sharedPool := r.PowerLibrary.GetSharedPool()
-		if sharedPool.GetPowerProfile() != nil && sharedPool.GetPowerProfile().Name() == profile.Spec.Name {
-			msg := fmt.Sprintf("updating shared pool in power library with updated profile '%s' for node '%s'", profile.Spec.Name, nodeName)
+		if sharedPool.GetPowerProfile() != nil && sharedPool.GetPowerProfile().Name() == profile.Name {
+			msg := fmt.Sprintf("updating shared pool in power library with updated profile '%s' for node '%s'", profile.Name, nodeName)
 			logger.V(5).Info(msg)
 			err := sharedPool.SetPowerProfile(powerProfile)
 			if err != nil {
@@ -251,8 +251,8 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		for _, pool := range *exclusivePools {
 			if strings.Contains(pool.Name(), nodeName+"-reserved-") &&
 				pool.GetPowerProfile() != nil &&
-				pool.GetPowerProfile().Name() == profile.Spec.Name {
-				msg := fmt.Sprintf("updating special reserved pool '%s' in power library with updated profile '%s' for node '%s'", pool.Name(), profile.Spec.Name, nodeName)
+				pool.GetPowerProfile().Name() == profile.Name {
+				msg := fmt.Sprintf("updating special reserved pool '%s' in power library with updated profile '%s' for node '%s'", pool.Name(), profile.Name, nodeName)
 				logger.V(5).Info(msg)
 				err := pool.SetPowerProfile(powerProfile)
 				if err != nil {
@@ -263,7 +263,7 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 		logger.V(5).Info(fmt.Sprintf(
 			"power profile successfully updated: name - %s max - %d min - %d EPP - %s",
-			profile.Spec.Name, powerProfile.GetPStates().GetMaxFreq().IntVal, powerProfile.GetPStates().GetMinFreq().IntVal, actualEpp))
+			profile.Name, powerProfile.GetPStates().GetMaxFreq().IntVal, powerProfile.GetPStates().GetMinFreq().IntVal, actualEpp))
 	}
 
 	if profile.Spec.Shared {
@@ -311,7 +311,7 @@ func (r *PowerProfileReconciler) ensureExtendedResources(ctx context.Context, no
 	}
 
 	profilesAvailable := resource.NewQuantity(numExtendedResources, resource.DecimalSI)
-	extendedResourceName := corev1.ResourceName(fmt.Sprintf("%s%s", ExtendedResourcePrefix, profile.Spec.Name))
+	extendedResourceName := corev1.ResourceName(fmt.Sprintf("%s%s", ExtendedResourcePrefix, profile.Name))
 	node.Status.Capacity[extendedResourceName] = *profilesAvailable
 
 	err = r.Client.Status().Update(ctx, node)
@@ -352,18 +352,18 @@ func (r *PowerProfileReconciler) removeExtendedResources(ctx context.Context, no
 
 // cleanupProfileFromNode removes only extended resources from a node when it no longer matches the PowerProfile selector.
 func (r *PowerProfileReconciler) cleanupProfileFromNode(ctx context.Context, profile *powerv1.PowerProfile, nodeName string, logger *logr.Logger) error {
-	logger.V(5).Info("Cleaning up PowerProfile extended resources from node", "profile", profile.Spec.Name, "nodeName", nodeName)
+	logger.V(5).Info("Cleaning up PowerProfile extended resources from node", "profile", profile.Name, "nodeName", nodeName)
 
 	// Only remove extended resources from the node.
 	// Keep pools, workloads, and shared PowerProfile configurations as pods/services may depend on them.
-	err := r.removeExtendedResources(ctx, nodeName, profile.Spec.Name, logger)
+	err := r.removeExtendedResources(ctx, nodeName, profile.Name, logger)
 	if err != nil {
 		logger.Error(err, "error removing extended resources")
 		return err
 	}
 
 	// Remove the profile from PowerNodeState since it no longer applies to this node.
-	err = removePowerNodeStatusProfileEntry(ctx, r.Client, nodeName, profile.Spec.Name, logger)
+	err = removePowerNodeStatusProfileEntry(ctx, r.Client, nodeName, profile.Name, logger)
 	if err != nil {
 		logger.Error(err, "error removing profile from PowerNodeState")
 		// Return the error so the caller can requeue to retry status cleanup.
@@ -371,7 +371,7 @@ func (r *PowerProfileReconciler) cleanupProfileFromNode(ctx context.Context, pro
 		return err
 	}
 
-	logger.V(5).Info("Successfully cleaned up PowerProfile extended resources from node", "profile", profile.Spec.Name, "nodeName", nodeName)
+	logger.V(5).Info("Successfully cleaned up PowerProfile extended resources from node", "profile", profile.Name, "nodeName", nodeName)
 	return nil
 }
 

--- a/controllers/powerprofile_controller_test.go
+++ b/controllers/powerprofile_controller_test.go
@@ -98,7 +98,6 @@ func TestPowerProfile_Reconcile_ExclusivePoolCreation(t *testing.T) {
 					Namespace: PowerNamespace,
 				},
 				Spec: powerv1.PowerProfileSpec{
-					Name: "performance",
 					PStates: powerv1.PStatesConfig{
 						Max:      &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 						Min:      &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -123,7 +122,6 @@ func TestPowerProfile_Reconcile_ExclusivePoolCreation(t *testing.T) {
 					Namespace: PowerNamespace,
 				},
 				Spec: powerv1.PowerProfileSpec{
-					Name: "performance",
 					PStates: powerv1.PStatesConfig{
 						Max:      &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 						Min:      &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -200,7 +198,6 @@ func TestPowerProfile_Reconcile_SharedPoolCreation(t *testing.T) {
 				Namespace: PowerNamespace,
 			},
 			Spec: powerv1.PowerProfileSpec{
-				Name:   "shared",
 				Shared: true,
 				PStates: powerv1.PStatesConfig{
 					Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
@@ -273,7 +270,6 @@ func TestPowerProfile_Reconcile_NonPowerProfileNotInLibrary(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -304,7 +300,6 @@ func TestPowerProfile_Reconcile_NonPowerProfileNotInLibrary(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max: nil,
 							Min: nil,
@@ -335,7 +330,6 @@ func TestPowerProfile_Reconcile_NonPowerProfileNotInLibrary(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "user-created",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -417,7 +411,6 @@ func TestPowerProfile_Reconcile_NonPowerProfileInLibrary(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -448,7 +441,6 @@ func TestPowerProfile_Reconcile_NonPowerProfileInLibrary(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max: nil,
 							Min: nil,
@@ -479,7 +471,6 @@ func TestPowerProfile_Reconcile_NonPowerProfileInLibrary(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "user-created",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -649,7 +640,6 @@ func TestPowerProfile_Reconcile_MaxMinFrequencyHandling(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: tc.profileName,
 						PStates: powerv1.PStatesConfig{
 							Max:      tc.max,
 							Min:      tc.min,
@@ -792,7 +782,6 @@ func TestPowerProfile_Reconcile_MaxMinFrequencyValidationErrors(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: tc.profileName,
 						PStates: powerv1.PStatesConfig{
 							Max:      tc.max,
 							Min:      tc.min,
@@ -857,7 +846,6 @@ func TestPowerProfile_Reconcile_IncorrectEppValue(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "user-created",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -925,7 +913,6 @@ func TestPowerProfile_Reconcile_SharedProfileDoesNotExistInLibrary(t *testing.T)
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name:   "shared",
 						Shared: true,
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 800},
@@ -1070,7 +1057,6 @@ func TestPowerProfile_Reconcile_AcpiDriver(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -1101,7 +1087,6 @@ func TestPowerProfile_Reconcile_AcpiDriver(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max: nil,
 							Min: nil,
@@ -1132,7 +1117,6 @@ func TestPowerProfile_Reconcile_AcpiDriver(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "user-created",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -1245,7 +1229,6 @@ func TestPowerProfile_Reconcile_LibraryErrs(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -1291,7 +1274,6 @@ func TestPowerProfile_Reconcile_LibraryErrs(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -1429,7 +1411,6 @@ func TestPowerProfile_Reconcile_FeatureNotSupportedErr(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name:   "shared",
 						Shared: true,
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
@@ -1460,7 +1441,6 @@ func TestPowerProfile_Reconcile_FeatureNotSupportedErr(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max: &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min: &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -1598,7 +1578,6 @@ func TestPowerProfile_Reconcile_UnsupportedGovernor(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: "performance",
 						PStates: powerv1.PStatesConfig{
 							Max:      &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min:      &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -1630,7 +1609,6 @@ func TestPowerProfile_Reconcile_UnsupportedGovernor(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name:   "shared",
 						Shared: true,
 						PStates: powerv1.PStatesConfig{
 							Max:      &intstr.IntOrString{Type: intstr.Int, IntVal: 1000},
@@ -1713,7 +1691,6 @@ func FuzzPowerProfileController(f *testing.F) {
 					Namespace: PowerNamespace,
 				},
 				Spec: powerv1.PowerProfileSpec{
-					Name: prof,
 					PStates: powerv1.PStatesConfig{
 						Max:      &intstr.IntOrString{Type: intstr.Int, IntVal: int32(maxVal)},
 						Min:      &intstr.IntOrString{Type: intstr.Int, IntVal: int32(minVal)},
@@ -1875,7 +1852,6 @@ func TestPowerProfile_Reconcile_ProfileUpdateAffectsAllPools(t *testing.T) {
 						Namespace: PowerNamespace,
 					},
 					Spec: powerv1.PowerProfileSpec{
-						Name: tc.profileName,
 						PStates: powerv1.PStatesConfig{
 							Max:      &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 							Min:      &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -2290,7 +2266,6 @@ func TestPowerProfile_Reconcile_NodeSelectorAndCapacity(t *testing.T) {
 					Namespace: PowerNamespace,
 				},
 				Spec: powerv1.PowerProfileSpec{
-					Name: tc.profileName,
 					PStates: powerv1.PStatesConfig{
 						Max:      &intstr.IntOrString{Type: intstr.Int, IntVal: 3600},
 						Min:      &intstr.IntOrString{Type: intstr.Int, IntVal: 3200},
@@ -2410,7 +2385,6 @@ func TestPowerProfile_Reconcile_NodeSelectorCleanup(t *testing.T) {
 			Namespace: PowerNamespace,
 		},
 		Spec: powerv1.PowerProfileSpec{
-			Name: profileName,
 			NodeSelector: powerv1.NodeSelector{
 				LabelSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{

--- a/docs/dpdk-dynamic-scaling.md
+++ b/docs/dpdk-dynamic-scaling.md
@@ -18,7 +18,6 @@ kind: PowerProfile
 metadata:
   name: dpdk-scaling
 spec:
-  name: dpdk-scaling
   pstates:
     governor: userspace
     min: 0%

--- a/examples/example-powerprofile-dpdk.yaml
+++ b/examples/example-powerprofile-dpdk.yaml
@@ -7,7 +7,6 @@ metadata:
  name: application-dpdk
  namespace: power-manager
 spec:
- name: application-dpdk
  # The CpuCapacity is used to set the maximum number of CPUs that can be used by the PowerProfile.
  cpuCapacity: 40
  # cpuCapacity: "50%"

--- a/examples/example-powerprofile.yaml
+++ b/examples/example-powerprofile.yaml
@@ -7,7 +7,6 @@ metadata:
  name: application
  namespace: power-manager
 spec:
- name: application
  # The CpuCapacity is used to set the maximum number of CPUs that can be used by the PowerProfile.
  cpuCapacity: 40
  # cpuCapacity: "50%"

--- a/examples/example-shared-profile.yaml
+++ b/examples/example-shared-profile.yaml
@@ -4,7 +4,6 @@ metadata:
   name: shared
   namespace: power-manager
 spec:
-  name: "shared"
   shared: true
   pstates:
     max: 1000

--- a/helm/crds/templates/crds.yaml
+++ b/helm/crds/templates/crds.yaml
@@ -219,13 +219,8 @@ spec:
               min:
                 description: Min frequency cores can run at
                 type: integer
-              name:
-                description: The name of the PowerProfile
-                type: string
               shared:
                 type: boolean
-            required:
-            - name
             type: object
           status:
             description: PowerProfileStatus defines the observed state of PowerProfile

--- a/helm/kubernetes-power-manager/values.yaml
+++ b/helm/kubernetes-power-manager/values.yaml
@@ -91,7 +91,6 @@ sharedprofile:
   name: shared
   namespace: power-manager
   spec:
-    name: "shared"
     max: 1000
     min: 1000
     epp: "power"

--- a/helm/manager-chart-library/templates/_new-shared-power-profile.tpl
+++ b/helm/manager-chart-library/templates/_new-shared-power-profile.tpl
@@ -5,7 +5,6 @@ metadata:
   name: {{ .Values.sharedprofile.name }}
   namespace: {{ .Values.sharedprofile.namespace }}
 spec:
-  name: {{ .Values.sharedprofile.spec.name }}
   max: {{ .Values.sharedprofile.spec.max }}
   min: {{ .Values.sharedprofile.spec.min }}
   epp: {{ .Values.sharedprofile.spec.epp }}

--- a/helm/manager-chart-library/templates/_shared-power-profile.tpl
+++ b/helm/manager-chart-library/templates/_shared-power-profile.tpl
@@ -5,7 +5,6 @@ metadata:
   name: {{ .Values.sharedprofile.name }}
   namespace: {{ .Values.sharedprofile.namespace }}
 spec:
-  name: {{ .Values.sharedprofile.spec.name }}
   max: {{ .Values.sharedprofile.spec.max }}
   min: {{ .Values.sharedprofile.spec.min }}
   epp: {{ .Values.sharedprofile.spec.epp }}


### PR DESCRIPTION
The spec.name field always duplicated metadata.name and served no independent purpose. All controller references now use the standard Kubernetes metadata name (profile.Name) instead.