### PR TITLE
Enable clean vanilla k8s deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-.PHONY: all test build images images-ocp run
+.PHONY: all test build images images-ocp build-push-images build-push-images-ocp run
 
 all: manifests generate install
 
@@ -183,6 +183,16 @@ images-ocp: generate manifests
 	 echo "Building images for OCP $(IMG) and $(IMG_AGENT)"
 	 $(IMGTOOL) build --build-arg="BASE_IMAGE=$(OCP_IMAGE)" --build-arg="MANIFEST=build/manifests/ocp/power-node-agent-ds.yaml" -f build/Dockerfile --platform $(PLATFORM) -t ${IMG} .
 	 $(IMGTOOL) build --build-arg="BASE_IMAGE=$(OCP_IMAGE)" -f build/Dockerfile.nodeagent --platform $(PLATFORM) -t ${IMG_AGENT} .
+
+# Build and push single-architecture images
+build-push-images: images
+	$(IMGTOOL) push ${IMG}
+	$(IMGTOOL) push ${IMG_AGENT}
+
+build-push-images-ocp: images-ocp
+	$(IMGTOOL) push ${IMG}
+	$(IMGTOOL) push ${IMG_AGENT}
+
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
 	go run ./build/manager/main.go
@@ -358,10 +368,7 @@ endif
 endif
 	@echo "Multi-arch images built and pushed successfully"
 
-.PHONY: docker-push controller-gen kustomize bundle bundle-build bundle-push
-# Push the image
-push:
-	$(IMGTOOL) push ${IMG}
+.PHONY: controller-gen kustomize bundle bundle-build bundle-push
 
 # Generate bundle manifests and metadata, then validate generated files.
 bundle: update manifests kustomize operator-sdk
@@ -455,10 +462,13 @@ gofmt:
 	gofmt -w .
 
 update:
+ifeq (false, $(OCP))
 	sed -i 's|image: .*|image: $(IMG)|' config/manager/manager.yaml
-	sed -i 's|image: .*|image: $(IMG)|' config/manager/ocp/manager.yaml
 	sed -i 's|image: .*|image: $(IMG_AGENT)|' build/manifests/power-node-agent-ds.yaml
+else
+	sed -i 's|image: .*|image: $(IMG)|' config/manager/ocp/manager.yaml
 	sed -i 's|image: .*|image: $(IMG_AGENT)|' build/manifests/ocp/power-node-agent-ds.yaml
+endif
 
 # markdownlint rules, following: https://github.com/openshift/enhancements/blob/master/Makefile
 .PHONY: markdownlint-image

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Kubernetes Power Manager
 
-> **⚠️ Notice:** A disruptive enhancement for multi-node cluster support is currently in progress on the `main` branch. For a stable codebase, please use the [v0.0.1](https://github.com/cluster-power-manager/cluster-power-manager/tree/v0.0.1) release tag.
-
 This is an experimental project based on https://github.com/intel/kubernetes-power-manager (which has been
 discontinued). It also includes enhancements from https://github.com/AMDEPYC/kubernetes-power-manager
 (e.g. Dynamic CPU Frequency Management based on DPDK telemetry).
@@ -180,6 +178,34 @@ The Kubernetes Power Manager supports all of the above use cases.
 
   > Note: Make sure to use the same label in the `PowerConfig`, under `spec.powerNodeSelector`.
 
+- **cert-manager** (vanilla Kubernetes only) — Required for webhook TLS certificate provisioning. On OpenShift,
+  certificates are managed automatically by the service-ca operator. cert-manager must be installed and ready
+  before deploying the Cluster Power Manager.
+
+  Install cert-manager using kubectl:
+
+  ```console
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+  ```
+
+  Or using Helm (OCI registry):
+
+  ```console
+  helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+    --namespace cert-manager \
+    --create-namespace \
+    --set crds.enabled=true
+  ```
+
+  Verify cert-manager is ready before proceeding:
+
+  ```console
+  kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=120s
+  ```
+
+  For more details, see the [official cert-manager installation guide](https://cert-manager.io/docs/installation/).
+  To uninstall, see the [cert-manager uninstall guide](https://cert-manager.io/docs/installation/uninstall/).
+
 - **Important**: In the kubelet configuration file the `cpuManagerPolicy` has to set to `static`, and the
   `reservedSystemCPUs` must be set to the desired value (full file [here](./examples/example-kubelet-configuration.yaml)):
 
@@ -192,39 +218,51 @@ The Kubernetes Power Manager supports all of the above use cases.
   ...
   ```
 
-## Deploying the Kubernetes Power Manager using kustomize
+## Building Images
 
-- Build the 2 images:
+The Cluster Power Manager requires two container images: the **Power Operator** (manager) and the **Power Node Agent**.
 
-  ```console
-  IMG_AGENT=quay.io/<user/org>/power-node-agent:latest IMG=quay.io/<user/org>/power-operator:latest IMGTOOL=<docker/podman> make update
+When building with custom image tags (different from the defaults), run `make update` first to update the image
+references in the deployment manifests. This ensures the operator deploys the node agent DaemonSet with the
+correct image.
 
-  OCP=true IMG_AGENT=quay.io/<user/org>/power-node-agent:latest IMG=quay.io/<user/org>/power-operator:latest IMGTOOL=<docker/podman> make images-ocp
-  ```
+```console
+IMG=quay.io/<user/org>/power-operator:<tag> \
+IMG_AGENT=quay.io/<user/org>/power-node-agent:<tag> \
+make update
 
-  > **Note**: By default, the images are built for x86_64 platforms. For an ARM platform, add the `PLATFORM=linux/arm64` parameter:
-  >
-  > ```console
-  > OCP=true IMG_AGENT=<...> IMG=<...> PLATFORM=linux/arm64 IMGTOOL=<...> make images-ocp
-  > ```
+# OpenShift
+OCP=true \
+IMG=quay.io/<user/org>/power-operator:<tag> \
+IMG_AGENT=quay.io/<user/org>/power-node-agent:<tag> \
+make update
+```
 
-- Push the 2 images:
+### Building Single-Architecture Images
 
-  ```console
-  <docker/podman> push <image>
-  ```
+Build both images for a single platform. `IMGTOOL` defaults to `docker` and `PLATFORM` defaults to `linux/amd64`.
 
-- Install the CRDs and deploy the operator:
+```console
+IMG=quay.io/<user/org>/power-operator:<tag> \
+IMG_AGENT=quay.io/<user/org>/power-node-agent:<tag> \
+IMGTOOL=<docker|podman> \
+PLATFORM=<linux/amd64|linux/arm64> \
+make build-push-images
 
-  ```console
-  OCP=true IMG_AGENT=quay.io/<user/org>/power-node-agent:latest IMG=quay.io/<user/org>/power-operator:latest make install deploy
-  ```
+# For OpenShift (uses UBI base image and OCP-specific manifests):
+OCP=true \
+IMG=quay.io/<user/org>/power-operator:<tag> \
+IMG_AGENT=quay.io/<user/org>/power-node-agent:<tag> \
+IMGTOOL=<docker|podman> \
+PLATFORM=<linux/amd64|linux/arm64> \
+make build-push-images-ocp
+```
 
-## Building Multi-Architecture Images
+### Building Multi-Architecture Images
 
 The Kubernetes Power Manager supports building multi-architecture container images for both the Power Operator and Power Node Agent. This allows you to create a single image tag that works across multiple architectures (e.g., AMD64 and ARM64).
 
-### Prerequisites
+#### Prerequisites
 
 **For Podman:**
 
@@ -257,7 +295,7 @@ docker buildx create --name multiarch --use
 docker buildx inspect --bootstrap
 ```
 
-### Build Multi-Arch Images
+#### Build Multi-Arch Images
 
 Build both operator and agent images for multiple architectures (default: linux/amd64 and linux/arm64):
 
@@ -285,7 +323,7 @@ VERSION=latest \
 make build-push-multiarch
 ```
 
-### Customizing Target Platforms
+#### Customizing Target Platforms
 
 Override the default platforms (linux/amd64,linux/arm64):
 
@@ -297,7 +335,7 @@ VERSION=latest \
 make build-push-multiarch
 ```
 
-### Verifying Multi-Arch Images
+#### Verifying Multi-Arch Images
 
 After pushing, verify the multi-arch manifest:
 
@@ -307,6 +345,25 @@ podman manifest inspect quay.io/<user/org>/kubernetes-power-manager-operator:lat
 
 # Using Docker
 docker buildx imagetools inspect quay.io/<user/org>/kubernetes-power-manager-operator:latest
+```
+
+## Deploying the Cluster Power Manager using kustomize
+
+Install the CRDs and deploy the operator:
+
+```console
+IMG=quay.io/<user/org>/power-operator:<tag> \
+IMG_AGENT=quay.io/<user/org>/power-node-agent:<tag> \
+make install deploy
+```
+
+For OpenShift:
+
+```console
+OCP=true \
+IMG=quay.io/<user/org>/power-operator:<tag> \
+IMG_AGENT=quay.io/<user/org>/power-node-agent:<tag> \
+make install deploy
 ```
 
 ## Deploying the Kubernetes Power Manager using Helm

--- a/build/Dockerfile.nodeagent
+++ b/build/Dockerfile.nodeagent
@@ -1,5 +1,4 @@
-
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora-minimal:42
 
 # Source for the lscpu binary - TARGETPLATFORM architecture
 FROM quay.io/projectquay/golang:1.24 AS lscpu-source

--- a/build/manifests/power-node-agent-ds.yaml
+++ b/build/manifests/power-node-agent-ds.yaml
@@ -60,4 +60,4 @@ spec:
         - name: pods
           hostPath:
             path: /var/lib/power-node-agent/pods
-            type: DirectoryOrCreat
+            type: DirectoryOrCreate

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,7 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
-# breaking changes
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
 # Used for vanilla K8s deployments with cert-manager.
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -53,11 +53,3 @@ rules:
   - uncores/finalizers
   verbs:
   - update
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - privileged
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use

--- a/controllers/powerconfig_controller.go
+++ b/controllers/powerconfig_controller.go
@@ -60,7 +60,6 @@ type PowerConfigReconciler struct {
 // +kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powerconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powernodestates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powernodestates/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 func (r *PowerConfigReconciler) Reconcile(c context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/powernodeconfig_controller.go
+++ b/controllers/powernodeconfig_controller.go
@@ -56,7 +56,6 @@ type PowerNodeConfigReconciler struct {
 // +kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powernodestates/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=list;watch
-// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 // Reconcile evaluates all PowerNodeConfigs matching this node, resolves conflicts,
 // and configures or cleans up shared and reserved CPU pools accordingly.

--- a/controllers/powerpod_controller.go
+++ b/controllers/powerpod_controller.go
@@ -75,7 +75,6 @@ type PowerPodReconciler struct {
 // +kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powerprofiles,verbs=get;list;watch
 // +kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powernodestates,verbs=get;list;watch
 // +kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powernodestates/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 func (r *PowerPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("powerpod", req.NamespacedName)

--- a/controllers/powerprofile_controller.go
+++ b/controllers/powerprofile_controller.go
@@ -59,7 +59,6 @@ type PowerProfileReconciler struct {
 // +kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powerprofiles/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powernodestates,verbs=get;list;watch
 // +kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powernodestates/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 // Reconcile method that implements the reconcile loop
 func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {

--- a/controllers/uncore_controller.go
+++ b/controllers/uncore_controller.go
@@ -57,7 +57,6 @@ type UncoreReconciler struct {
 //+kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powernodestates,verbs=get;list;watch
 //+kubebuilder:rbac:groups=power.cluster-power-manager.github.io,resources=powernodestates/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
-//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 // Reconcile evaluates all Uncore CRs matching this node, resolves conflicts,
 // and configures or cleans up uncore frequency settings accordingly.

--- a/power-optimization-library/pkg/power/host.go
+++ b/power-optimization-library/pkg/power/host.go
@@ -136,7 +136,7 @@ func (host *hostImpl) GetVendorID() string {
 // GetFromLscpu returns the value of a certain key from the lscpu output.
 var GetFromLscpu = func(regex string) (string, error) {
 	regexp.MustCompile(regex)
-	cmdStr := fmt.Sprintf("lscpu | egrep -w \"%s\" | cut -d ':' -f 2", regex)
+	cmdStr := fmt.Sprintf("lscpu | grep -Ew \"%s\" | cut -d ':' -f 2", regex)
 	cmd := exec.Command("bash", "-c", cmdStr)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/vendor/github.com/intel/power-optimization-library/pkg/power/host.go
+++ b/vendor/github.com/intel/power-optimization-library/pkg/power/host.go
@@ -136,7 +136,7 @@ func (host *hostImpl) GetVendorID() string {
 // GetFromLscpu returns the value of a certain key from the lscpu output.
 var GetFromLscpu = func(regex string) (string, error) {
 	regexp.MustCompile(regex)
-	cmdStr := fmt.Sprintf("lscpu | egrep -w \"%s\" | cut -d ':' -f 2", regex)
+	cmdStr := fmt.Sprintf("lscpu | grep -Ew \"%s\" | cut -d ':' -f 2", regex)
 	cmd := exec.Command("bash", "-c", cmdStr)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr


### PR DESCRIPTION
- Fix DaemonSet manifest typo: DirectoryOrCreat -> DirectoryOrCreate
- Remove security.openshift.io SCC from vanilla RBAC and kubebuilder markers
- Switch node agent base image to fedora-minimal:42 (`distroless/static` lacks the libraries `libsmartcols` and `glibcc` needed by POL's lscpu)
- Fix POL egrep deprecation warning: use grep -E
- Document cert-manager as prerequisite for vanilla k8s webhook certs
- Reorganize README build and deploy instructions