### PR TITLE
Add GitHub Actions CI, CodeQL, and OpenSSF Scorecard workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      ci:
+        patterns:
+          - "*" # Group all GitHub Actions updates into a single PR

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - LICENSE
+      - OWNERS
+      - OWNERS_ALIASES
+      - .gitignore
+      - docs/**
+      - hack/**
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - LICENSE
+      - OWNERS
+      - OWNERS_ALIASES
+      - .gitignore
+      - docs/**
+      - hack/**
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: Generate, build CRDs, and run unit and integration tests
+        run: make test
+
+  images:
+    name: Images
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 20
+    env:
+      REGISTRY: ghcr.io
+      OPERATOR_IMAGE: ghcr.io/cluster-power-manager/cluster-power-manager-operator
+      AGENT_IMAGE: ghcr.io/cluster-power-manager/cluster-power-node-agent
+      IMAGE_TAG: latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Log in to ghcr.io
+        if: github.event_name == 'push'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: ${{ github.event_name == 'push' && 'Build and push operator image' || 'Build operator image' }}
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: build/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ${{ env.OPERATOR_IMAGE }}:${{ env.IMAGE_TAG }}
+            ${{ env.OPERATOR_IMAGE }}:${{ github.sha }}
+      - name: ${{ github.event_name == 'push' && 'Build and push agent image' || 'Build agent image' }}
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: build/Dockerfile.nodeagent
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ${{ env.AGENT_IMAGE }}:${{ env.IMAGE_TAG }}
+            ${{ env.AGENT_IMAGE }}:${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,6 @@ on:
     paths-ignore:
       - "**.md"
       - LICENSE
-      - OWNERS
-      - OWNERS_ALIASES
       - .gitignore
       - docs/**
       - hack/**
@@ -17,8 +15,6 @@ on:
     paths-ignore:
       - "**.md"
       - LICENSE
-      - OWNERS
-      - OWNERS_ALIASES
       - .gitignore
       - docs/**
       - hack/**
@@ -52,8 +48,11 @@ jobs:
     env:
       REGISTRY: ghcr.io
       OPERATOR_IMAGE: ghcr.io/cluster-power-manager/cluster-power-manager-operator
+      OPERATOR_DESCRIPTION: Cluster Power Manager Operator
       AGENT_IMAGE: ghcr.io/cluster-power-manager/cluster-power-node-agent
+      AGENT_DESCRIPTION: Cluster Power Manager Node Agent
       IMAGE_TAG: latest
+      DOCKER_METADATA_ANNOTATIONS_LEVELS: index
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -69,6 +68,14 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Operator image metadata
+        id: operator-meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.OPERATOR_IMAGE }}
+          tags: type=raw,value=${{ env.IMAGE_TAG }}
+          labels: org.opencontainers.image.description=${{ env.OPERATOR_DESCRIPTION }}
+          annotations: org.opencontainers.image.description=${{ env.OPERATOR_DESCRIPTION }}
       - name: ${{ github.event_name == 'push' && 'Build and push operator image' || 'Build operator image' }}
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -76,9 +83,17 @@ jobs:
           file: build/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
-          tags: |
-            ${{ env.OPERATOR_IMAGE }}:${{ env.IMAGE_TAG }}
-            ${{ env.OPERATOR_IMAGE }}:${{ github.sha }}
+          tags: ${{ steps.operator-meta.outputs.tags }}
+          labels: ${{ steps.operator-meta.outputs.labels }}
+          annotations: ${{ steps.operator-meta.outputs.annotations }}
+      - name: Agent image metadata
+        id: agent-meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.AGENT_IMAGE }}
+          tags: type=raw,value=${{ env.IMAGE_TAG }}
+          labels: org.opencontainers.image.description=${{ env.AGENT_DESCRIPTION }}
+          annotations: org.opencontainers.image.description=${{ env.AGENT_DESCRIPTION }}
       - name: ${{ github.event_name == 'push' && 'Build and push agent image' || 'Build agent image' }}
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -86,6 +101,6 @@ jobs:
           file: build/Dockerfile.nodeagent
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
-          tags: |
-            ${{ env.AGENT_IMAGE }}:${{ env.IMAGE_TAG }}
-            ${{ env.AGENT_IMAGE }}:${{ github.sha }}
+          tags: ${{ steps.agent-meta.outputs.tags }}
+          labels: ${{ steps.agent-meta.outputs.labels }}
+          annotations: ${{ steps.agent-meta.outputs.annotations }}

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,56 @@
+# CodeQL scans Go source code for security vulnerabilities (e.g., injection,
+# path traversal). Results appear in the repo's
+# Security tab > Code scanning.
+name: "CodeQL Scan"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - LICENSE
+      - OWNERS
+      - OWNERS_ALIASES
+      - .gitignore
+      - docs/**
+      - hack/**
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - LICENSE
+      - OWNERS
+      - OWNERS_ALIASES
+      - .gitignore
+      - docs/**
+      - hack/**
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          languages: go
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          category: "/language:go"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -10,8 +10,6 @@ on:
     paths-ignore:
       - "**.md"
       - LICENSE
-      - OWNERS
-      - OWNERS_ALIASES
       - .gitignore
       - docs/**
       - hack/**
@@ -20,8 +18,6 @@ on:
     paths-ignore:
       - "**.md"
       - LICENSE
-      - OWNERS
-      - OWNERS_ALIASES
       - .gitignore
       - docs/**
       - hack/**

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,49 @@
+# OpenSSF Scorecard assesses the repo's security posture (branch protection,
+# dependency management, CI config, etc.). Results appear in the repo's
+# Security tab > Code scanning.
+name: OpenSSF Scorecard
+
+on:
+  workflow_dispatch:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 8 1 * *" # First day of each month at 8:00 AM UTC
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    name: Scorecard
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to sign Scorecard results and receive a badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: false
+      - name: Upload Scorecard results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 30
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
CI workflow (.github/workflows/ci.yaml):
- Test job: runs make test (generate, CRDs, unit/integration tests) on PR and push to main
- Images job: builds multi-arch (amd64/arm64) operator and agent container images. On PR: build only (validates images compile). On merge to main: build and push to ghcr.io with :latest tag.
- Images job depends on Test (needs: [test]) to prevent pushing images when tests fail on merge to main.

CodeQL workflow (.github/workflows/codeql.yaml):
- Scans Go source code for security vulnerabilities (injection, path traversal, etc.)
- Runs on PR and push to main to catch issues before and after merging
- Results appear in the repo Security tab > Code scanning

OpenSSF Scorecard workflow (.github/workflows/scorecard.yaml):
- Assesses repo security posture (branch protection, dependency management, CI config)
- Runs on monthly schedule, and branch protection changes
- Results appear in the repo Security tab > Code scanning

Also updates:
- All actions pinned to SHA with patch version comments for security and auditability
- .github/dependabot.yml: add github-actions ecosystem with grouping so Dependabot automatically opens PRs to update action SHAs and version comments when new releases are available. Updates are grouped into a single monthly PR.