### PR TITLE
Add lint CI job for golang and fix lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,23 @@ jobs:
       - name: Generate, build CRDs, and run unit and integration tests
         run: make test
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: golangci-lint
+        run: make golangci-lint
+
   images:
     name: Images
-    needs: [test]
+    needs: [test, lint]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,62 @@
+version: "2"
 run:
-  skip-files:
-    # exclude tests
-    - "_test\\.go$"
+  timeout: 5m
+linters:
+  default: none
+  enable:
+    - goconst        # finds repeated strings that could be constants
+    - gocritic       # code style, diagnostics, and performance checks
+    - govet          # go vet checks
+    - gosec          # security checks
+    # - gocyclo      # TODO: cyclomatic complexity
+    - ineffassign    # unused variable assignments
+    - staticcheck    # comprehensive static analysis
+    - unused         # unused code detection
+    - misspell       # catches common spelling mistakes in comments/strings
+    - unconvert      # removes unnecessary type conversions
+    - unparam        # reports unused function parameters
+    - errorlint      # finds issues with error wrapping
+  exclusions:
+    generated: lax # skip generated files
+    rules:
+      - path: (_test\.go|test_common\.go)
+        linters:
+          - unused
+          - unparam
+          - gosec
+
+  settings:
+    goconst:
+      ignore-tests: true
+    gosec:
+      excludes:
+        - G115 # integer overflow conversions — safe for CPU IDs and frequencies
+    gocritic:
+      enabled-checks: # Keep only non-default ones
+        # Diagnostic
+        - commentedOutCode
+        - nilValReturn
+        - weakCond
+        - octalLiteral
+        - sloppyReassign
+        # Performance
+        - equalFold
+        - indexAlloc
+        - rangeExprCopy
+        - appendCombine
+    staticcheck:
+      checks:
+        - all
+        # Exclude some staticcheck rules
+        - -QF1008 # embedded field selector simplification
+        - -ST1000 # package comments
+        # TODO: temporarily disable ST1003 to unblock existing linting
+        - -ST1003 # naming conventions
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
 output:
   sort-results: true

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ OPERATOR_SDK_VERSION ?= 1.42.0
 # OPM_VERSION defines the opm version to download from GitHub releases.
 OPM_VERSION ?= v1.52.0
 
+# GOLANGCI_LINT_VERSION defines the golangci-lint version to download.
+GOLANGCI_LINT_VERSION ?= v2.12.2
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.32.0
 ENVTEST_VERSION ?= release-0.21
@@ -69,6 +72,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 OPM ?= $(LOCALBIN)/opm
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 .PHONY: kubectl
 kubectl: $(KUBECTL) ## Use envtest to download kubectl
@@ -115,6 +119,19 @@ $(ENVTEST): $(LOCALBIN)
 		echo "Downloading setup-envtest..." ;\
 		GOFLAGS="-mod=mod" GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION) ;\
 		echo "setup-envtest downloaded successfully." ;\
+	fi
+
+.PHONY: golangci-lint-download
+golangci-lint-download: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary. If wrong version is installed, it will be removed before downloading.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	@if test -x $(GOLANGCI_LINT) && ! $(GOLANGCI_LINT) version 2>/dev/null | grep -q "$(subst v,,$(GOLANGCI_LINT_VERSION))"; then \
+		echo "$(GOLANGCI_LINT) version is not expected $(GOLANGCI_LINT_VERSION). Removing it before installing."; \
+		rm -rf $(GOLANGCI_LINT); \
+	fi
+	@if [ ! -f $(GOLANGCI_LINT) ]; then \
+		echo "Downloading golangci-lint..." ;\
+		curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION) ;\
+		echo "golangci-lint downloaded successfully." ;\
 	fi
 
 # Options for 'bundle-build'
@@ -223,7 +240,7 @@ helm-uninstall:
 	helm uninstall cluster-power-manager-$(HELM_CHART)
 	helm uninstall cluster-power-manager-crds
 
-.PHONY: install uninstall deploy manifests fmt vet tls
+.PHONY: install uninstall deploy manifests fmt vet tls golangci-lint
 # Install CRDs into a cluster
 install: manifests kustomize
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
@@ -269,6 +286,12 @@ fmt:
 # Run go vet against code
 vet:
 	go vet -composites=false ./...
+
+# Run golangci-lint against code
+golangci-lint: golangci-lint-download
+	@echo "Running golangci-lint on repository go files..."
+	$(GOLANGCI_LINT) run -v
+	@echo "Golangci-lint linting completed successfully."
 
 # Testing the generation of TLS certificates
 tls:

--- a/api/v1alpha1/powernodeconfig_webhook_test.go
+++ b/api/v1alpha1/powernodeconfig_webhook_test.go
@@ -274,7 +274,9 @@ func TestPowerNodeConfigConflictDetection(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			objs := append(tc.existing, tc.nodes...)
+			objs := make([]client.Object, 0, len(tc.existing)+len(tc.nodes))
+			objs = append(objs, tc.existing...)
+			objs = append(objs, tc.nodes...)
 			v := &powerNodeConfigValidator{Client: newFakeClient(objs...)}
 			errs := v.validateNodeSelectorConflicts(context.TODO(), tc.config)
 			if tc.wantErr {

--- a/api/v1alpha1/powerprofile_types.go
+++ b/api/v1alpha1/powerprofile_types.go
@@ -99,6 +99,7 @@ type CStatesConfig struct {
 	MaxLatencyUs *int `json:"maxLatencyUs,omitempty"`
 }
 
+// CpuScalingPolicy configures DPDK telemetry-based dynamic CPU frequency scaling.
 // +kubebuilder:validation:XValidation:rule="duration(self.samplePeriod).getMilliseconds() >= 10 && duration(self.samplePeriod).getMilliseconds() <= 1000",message="samplePeriod must be between 10ms and 1s"
 // +kubebuilder:validation:XValidation:rule="duration(self.cooldownPeriod).getMilliseconds() >= duration(self.samplePeriod).getMilliseconds()",message="cooldownPeriod must be larger than samplePeriod"
 type CpuScalingPolicy struct {

--- a/api/v1alpha1/uncore_webhook_test.go
+++ b/api/v1alpha1/uncore_webhook_test.go
@@ -243,7 +243,9 @@ func TestUncoreConflictDetection(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			objs := append(tc.existing, tc.nodes...)
+			objs := make([]client.Object, 0, len(tc.existing)+len(tc.nodes))
+			objs = append(objs, tc.existing...)
+			objs = append(objs, tc.nodes...)
 			v := &uncoreValidator{Client: newFakeClient(objs...), Namespace: testNamespace}
 			errs := v.validateNodeSelectorConflicts(context.TODO(), tc.uncore)
 			if tc.wantErr {

--- a/build/nodeagent/main.go
+++ b/build/nodeagent/main.go
@@ -121,6 +121,8 @@ func main() {
 	cpuScalingMgr := scaling.NewCPUScalingManager(&powerLibrary, dpdkClient)
 	if err = mgr.Add(cpuScalingMgr); err != nil {
 		setupLog.Error(err, "unable to register runnable", "runnable", "CPUScalingManager")
+		//nolint:gocritic // exitAfterDefer: os.Exit calls before mgr.Start() here are during setup/registration, no DPDK connections exist yet,
+		// so skipping the defer of DPDK connections cleanup is safe. The defer is needed for graceful shutdown when mgr.Start() returns.
 		os.Exit(1)
 	}
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (
@@ -34,10 +35,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const queuetime = time.Second * 5
-
-// FieldOwnerPowerProfileController is the base field manager name for PowerProfile controller.
-const FieldOwnerPowerProfileController = "powerprofile-controller"
+const (
+	queuetime          = time.Second * 5
+	PowerNodeStateKind = "PowerNodeState"
+	// FieldOwnerPowerProfileController is the base field manager name for PowerProfile controller.
+	FieldOwnerPowerProfileController = "powerprofile-controller"
+)
 
 // powerProfileFieldManager returns the field manager name for a specific PowerProfile.
 // Using per-profile field managers enables SSA to track ownership at the element level
@@ -239,8 +242,8 @@ func formatCpuScalingPolicy(policy *powerv1alpha1.CpuScalingPolicy) (string, err
 func applyPowerNodeStateProfilesStatus(ctx context.Context, c client.Client, powerNodeStateName string, profiles []powerv1alpha1.PowerNodeProfileStatus, fieldManager string) error {
 	patchNodeState := &powerv1alpha1.PowerNodeState{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "power.cluster-power-manager.github.io/v1alpha1",
-			Kind:       "PowerNodeState",
+			APIVersion: powerv1alpha1.GroupVersion.String(),
+			Kind:       PowerNodeStateKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      powerNodeStateName,

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -153,8 +153,8 @@ func Test_addPowerNodeStatusProfileEntry(t *testing.T) {
 			shouldVerifyPatchObject: true,
 			verifyPatchedObject: func(t *testing.T, pns *powerv1alpha1.PowerNodeState) {
 				// Verify TypeMeta and ObjectMeta are set correctly.
-				assert.Equal(t, "power.cluster-power-manager.github.io/v1alpha1", pns.APIVersion, "APIVersion should be set for SSA")
-				assert.Equal(t, "PowerNodeState", pns.Kind, "Kind should be set for SSA")
+				assert.Equal(t, powerv1alpha1.GroupVersion.String(), pns.APIVersion, "APIVersion should be set for SSA")
+				assert.Equal(t, PowerNodeStateKind, pns.Kind, "Kind should be set for SSA")
 				assert.Equal(t, "test-node-power-state", pns.Name)
 				assert.Equal(t, PowerNamespace, pns.Namespace)
 
@@ -173,8 +173,8 @@ func Test_addPowerNodeStatusProfileEntry(t *testing.T) {
 			expectError:             false,
 			verifyPatchedObject: func(t *testing.T, pns *powerv1alpha1.PowerNodeState) {
 				// Verify TypeMeta and ObjectMeta are set for SSA.
-				assert.Equal(t, "power.cluster-power-manager.github.io/v1alpha1", pns.APIVersion, "APIVersion should be set for SSA")
-				assert.Equal(t, "PowerNodeState", pns.Kind, "Kind should be set for SSA")
+				assert.Equal(t, powerv1alpha1.GroupVersion.String(), pns.APIVersion, "APIVersion should be set for SSA")
+				assert.Equal(t, PowerNodeStateKind, pns.Kind, "Kind should be set for SSA")
 				assert.Equal(t, "test-node-power-state", pns.Name)
 				assert.Equal(t, PowerNamespace, pns.Namespace)
 

--- a/controllers/envtest_common_test.go
+++ b/controllers/envtest_common_test.go
@@ -130,8 +130,8 @@ func applyNodeInfo(t *testing.T, cl client.Client, pnsName string) {
 	t.Helper()
 	patchNodeState := &powerv1alpha1.PowerNodeState{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "power.cluster-power-manager.github.io/v1alpha1",
-			Kind:       "PowerNodeState",
+			APIVersion: powerv1alpha1.GroupVersion.String(),
+			Kind:       PowerNodeStateKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pnsName,

--- a/controllers/powerconfig_controller.go
+++ b/controllers/powerconfig_controller.go
@@ -237,8 +237,8 @@ func (r *PowerConfigReconciler) applyNodeInfo(ctx context.Context, node *corev1.
 
 	patchNodeState := &powerv1alpha1.PowerNodeState{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "power.cluster-power-manager.github.io/v1alpha1",
-			Kind:       "PowerNodeState",
+			APIVersion: powerv1alpha1.GroupVersion.String(),
+			Kind:       PowerNodeStateKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      powerNodeStateName,
@@ -310,7 +310,7 @@ func (r *PowerConfigReconciler) createDaemonSetIfNotPresent(c context.Context, p
 }
 
 func createDaemonSetFromManifest(path string) (*appsv1.DaemonSet, error) {
-	yamlFile, err := os.ReadFile(path)
+	yamlFile, err := os.ReadFile(path) //nolint:gosec // path is from NodeAgentDaemonSetPath, not user input
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/powernodeconfig_controller.go
+++ b/controllers/powernodeconfig_controller.go
@@ -172,7 +172,7 @@ func (r *PowerNodeConfigReconciler) applyPowerNodeConfig(
 		return ctrl.Result{}, err
 	}
 
-	reservedProfileCPUs, reservedErrors := r.configureReservedPools(config, nodeName, logger)
+	reservedProfileCPUs, reservedErrors := r.configureReservedPools(config, nodeName)
 
 	// Collect all status errors.
 	var statusErrors []string
@@ -271,7 +271,6 @@ func (r *PowerNodeConfigReconciler) configureSharedPool(config *powerv1alpha1.Po
 func (r *PowerNodeConfigReconciler) configureReservedPools(
 	config *powerv1alpha1.PowerNodeConfig,
 	nodeName string,
-	logger *logr.Logger,
 ) ([]powerv1alpha1.PowerProfileCPUs, []error) {
 	// Remove existing pseudo-reserved pools.
 	pools := r.PowerLibrary.GetAllExclusivePools()
@@ -398,8 +397,8 @@ func (r *PowerNodeConfigReconciler) updatePowerNodeStatusPools(
 
 	patchNodeState := &powerv1alpha1.PowerNodeState{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "power.cluster-power-manager.github.io/v1alpha1",
-			Kind:       "PowerNodeState",
+			APIVersion: powerv1alpha1.GroupVersion.String(),
+			Kind:       PowerNodeStateKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      powerNodeStateName,
@@ -428,8 +427,8 @@ func (r *PowerNodeConfigReconciler) removePowerNodeStatusPools(ctx context.Conte
 
 	patchNodeState := &powerv1alpha1.PowerNodeState{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "power.cluster-power-manager.github.io/v1alpha1",
-			Kind:       "PowerNodeState",
+			APIVersion: powerv1alpha1.GroupVersion.String(),
+			Kind:       PowerNodeStateKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      powerNodeStateName,

--- a/controllers/powernodeconfig_controller_test.go
+++ b/controllers/powernodeconfig_controller_test.go
@@ -574,8 +574,7 @@ func TestConfigureReservedPools(t *testing.T) {
 			hostMk := tc.setupMock()
 			config := newPowerNodeConfig("c", "p", nil, tc.reserved, time.Now())
 			r := &PowerNodeConfigReconciler{PowerLibrary: hostMk}
-			logger := testLogger()
-			cpus, errs := r.configureReservedPools(config, "test-node", &logger)
+			cpus, errs := r.configureReservedPools(config, "test-node")
 			assert.Len(t, cpus, tc.expectedCPUCount)
 			assert.Len(t, errs, tc.expectedErrCount)
 		})

--- a/controllers/powerpod_controller.go
+++ b/controllers/powerpod_controller.go
@@ -353,7 +353,7 @@ func (r *PowerPodReconciler) getPowerProfileRequestsFromContainers(ctx context.C
 		cleanCoreList := getCleanCoreList(coreIDs)
 		logger.V(5).Info("reserving cores to container.", "ContainerID", containerID, "Cores", cleanCoreList)
 
-		// Accounts for case where cores aquired through DRA don't match profile requests.
+		// Accounts for case where cores acquired through DRA don't match profile requests.
 		if len(cleanCoreList) != requestNum {
 			recoverableErrs = append(recoverableErrs, fmt.Errorf("assigned cores did not match requested profiles. cores:%d, profiles %d", len(cleanCoreList), requestNum))
 			continue
@@ -420,11 +420,18 @@ func checkResource(container corev1.Container, resource corev1.ResourceName, num
 	return numRequestsCPU, numLimitsCPU
 }
 
+func allPodContainers(pod *corev1.Pod) []corev1.Container {
+	containers := make([]corev1.Container, 0, len(pod.Spec.InitContainers)+len(pod.Spec.Containers))
+	containers = append(containers, pod.Spec.InitContainers...)
+	containers = append(containers, pod.Spec.Containers...)
+	return containers
+}
+
 func getAdmissibleContainers(pod *corev1.Pod, resourceClient podresourcesclient.PodResourcesClient, logger *logr.Logger) []corev1.Container {
 
 	logger.V(5).Info("receiving containers requesting exclusive CPUs")
 	admissibleContainers := make([]corev1.Container, 0)
-	containerList := append(pod.Spec.InitContainers, pod.Spec.Containers...)
+	containerList := allPodContainers(pod)
 	controlPlaneAvailable := pingControlPlane(resourceClient)
 	for _, container := range containerList {
 		if doesContainerRequireExclusiveCPUs(pod, &container, logger) || controlPlaneAvailable {
@@ -465,7 +472,10 @@ func pingControlPlane(client podresourcesclient.PodResourcesClient) bool {
 }
 
 func getContainerID(pod *corev1.Pod, containerName string) string {
-	for _, containerStatus := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+	statuses := make([]corev1.ContainerStatus, 0, len(pod.Status.InitContainerStatuses)+len(pod.Status.ContainerStatuses))
+	statuses = append(statuses, pod.Status.InitContainerStatuses...)
+	statuses = append(statuses, pod.Status.ContainerStatuses...)
+	for _, containerStatus := range statuses {
 		if containerStatus.Name == containerName {
 			return containerStatus.ContainerID
 		}
@@ -516,8 +526,7 @@ func PowerReleventPodPredicate(obj client.Object) bool {
 	if pod.Spec.NodeName != os.Getenv("NODE_NAME") {
 		return false
 	}
-	containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
-	for _, c := range containers {
+	for _, c := range allPodContainers(pod) {
 		// No need to check the limits, as if the requests are present,
 		// the limits must be present as well.
 		for rn := range c.Resources.Requests {
@@ -536,8 +545,8 @@ func PowerReleventPodPredicate(obj client.Object) bool {
 func (r *PowerPodReconciler) applyPowerNodeStateExclusiveStatus(ctx context.Context, powerNodeStateName string, exclusive []powerv1alpha1.ExclusiveCPUPoolStatus, fieldManager string) error {
 	patchNodeState := &powerv1alpha1.PowerNodeState{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "power.cluster-power-manager.github.io/v1alpha1",
-			Kind:       "PowerNodeState",
+			APIVersion: powerv1alpha1.GroupVersion.String(),
+			Kind:       PowerNodeStateKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      powerNodeStateName,
@@ -722,8 +731,7 @@ func (r *PowerPodReconciler) powerProfileToPodRequests(ctx context.Context, obj 
 
 	profileName := obj.GetName()
 	for _, pod := range podList.Items {
-		containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
-		for _, c := range containers {
+		for _, c := range allPodContainers(&pod) {
 			for rn := range c.Resources.Requests {
 				if string(rn) == ResourcePrefix+profileName {
 					requests = append(requests, reconcile.Request{

--- a/controllers/powerpod_controller_test.go
+++ b/controllers/powerpod_controller_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	//"k8s.io/apimachinery/pkg/api/errors"
 	"go.uber.org/zap/zapcore"
 	grpc "google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -33,7 +32,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	//"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -1958,7 +1956,6 @@ func TestPowerPod_ValidateProfileNodeSelectorMatching(t *testing.T) {
 			}
 
 			// Verify result properties
-			assert.False(t, result.Requeue)
 			assert.Equal(t, time.Duration(0), result.RequeueAfter)
 		})
 	}

--- a/controllers/powerprofile_controller.go
+++ b/controllers/powerprofile_controller.go
@@ -231,7 +231,7 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		msg := fmt.Sprintf("updating the power profile '%s' to the power library for node '%s'", profile.Name, nodeName)
 		logger.V(5).Info(msg)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("error %s: %v", msg, err)
+			return ctrl.Result{}, fmt.Errorf("error %s: %w", msg, err)
 		}
 
 		// Update shared pool if it uses this profile
@@ -241,7 +241,7 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			logger.V(5).Info(msg)
 			err := sharedPool.SetPowerProfile(powerProfile)
 			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("error %s: %v", msg, err)
+				return ctrl.Result{}, fmt.Errorf("error %s: %w", msg, err)
 			}
 		}
 
@@ -255,7 +255,7 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				logger.V(5).Info(msg)
 				err := pool.SetPowerProfile(powerProfile)
 				if err != nil {
-					return ctrl.Result{}, fmt.Errorf("error %s: %v", msg, err)
+					return ctrl.Result{}, fmt.Errorf("error %s: %w", msg, err)
 				}
 			}
 		}
@@ -273,7 +273,7 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Create or update the extended resources for the profile.
 	err = r.ensureExtendedResources(ctx, nodeName, profile, &logger)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("error creating or updating the extended resources for the base profile: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error creating or updating the extended resources for the base profile: %w", err)
 	}
 
 	// If the workload already exists then the power profile was just updated and the power library will take care of reconfiguring cores

--- a/controllers/powerprofile_controller_test.go
+++ b/controllers/powerprofile_controller_test.go
@@ -1946,15 +1946,16 @@ func TestPowerProfile_Reconcile_ProfileUpdateAffectsAllPools(t *testing.T) {
 			verifyProfileParameters(currentProfile, tc.profileName, 3600, 3200,
 				"powersave", "performance", map[string]bool{"C0": true, "C1": true, "C1E": false, "C3": false})
 
-			if tc.expectSharedUpdate {
+			switch {
+			case tc.expectSharedUpdate:
 				currentProfile := sharedPool.GetPowerProfile()
 				assert.NotNil(t, currentProfile, "Shared pool should have the updated profile")
 				verifyProfileParameters(currentProfile, tc.profileName, 3600, 3200,
 					"powersave", "performance", map[string]bool{"C0": true, "C1": true, "C1E": false, "C3": false})
-			} else if tc.setupSharedPoolProfile == "" {
+			case tc.setupSharedPoolProfile == "":
 				currentProfile := sharedPool.GetPowerProfile()
 				assert.Nil(t, currentProfile, "Shared pool should not have a profile")
-			} else if tc.setupSharedPoolProfile == tc.otherProfileName {
+			case tc.setupSharedPoolProfile == tc.otherProfileName:
 				currentProfile := sharedPool.GetPowerProfile()
 				assert.NotNil(t, currentProfile, "Shared pool should have the original profile")
 				verifyProfileParameters(currentProfile, tc.otherProfileName, 3000, 2000,

--- a/controllers/test_helper_test.go
+++ b/controllers/test_helper_test.go
@@ -511,7 +511,7 @@ func (cl *DPDKTelemetryClientMock) Close() { cl.Called() }
 func intPtr(v int) *int { return &v }
 
 func setupDummyFiles(cores int, packages int, diesPerPackage int, cpufiles map[string]string) (power.Host, func(), error) {
-	//variables for various files
+	// variables for various files
 	path := "testing/cpus"
 	pStatesDrvFile := "cpufreq/scaling_driver"
 
@@ -542,13 +542,12 @@ func setupDummyFiles(cores int, packages int, diesPerPackage int, cpufiles map[s
 	_, ok := cpufiles["uncore_max"]
 	if ok {
 		os.Mkdir("testing", os.ModePerm)
-		os.WriteFile("testing/proc.modules", []byte("intel_uncore_frequency"+"\n"), 0644)
+		os.WriteFile("testing/proc.modules", []byte("intel_uncore_frequency"+"\n"), 0o644)
 		os.MkdirAll(filepath.Join(uncoreDir, "package_00_die_00"), os.ModePerm)
 	}
 	die := 0
 	pkg := 0
-	strPkg := "00"
-	strDie := "00"
+	var strPkg, strDie string
 	pkgDir := "package_00_die_00/"
 	increment := diesPerPackage * packages
 	coresPerDie := cores / increment
@@ -557,7 +556,7 @@ func setupDummyFiles(cores int, packages int, diesPerPackage int, cpufiles map[s
 		cpudir := filepath.Join(path, cpuName)
 		os.MkdirAll(filepath.Join(cpudir, "cpufreq"), os.ModePerm)
 		os.MkdirAll(filepath.Join(cpudir, "topology"), os.ModePerm)
-		//used to divide cores between packages and dies
+		// used to divide cores between packages and dies
 		if i%coresPerDie == 0 && i != 0 && packages != 0 {
 			if die == diesPerPackage-1 && pkg != (packages-1) {
 				die = 0
@@ -580,42 +579,42 @@ func setupDummyFiles(cores int, packages int, diesPerPackage int, cpufiles map[s
 			os.MkdirAll(filepath.Join(uncoreDir, pkgDir), os.ModePerm)
 		}
 		if packages != 0 {
-			os.WriteFile(filepath.Join(cpudir, packageIdFile), []byte(fmt.Sprint(pkg)+"\n"), 0664)
-			os.WriteFile(filepath.Join(cpudir, dieIdFile), []byte(fmt.Sprint(die)+"\n"), 0664)
-			os.WriteFile(filepath.Join(cpudir, coreIdFile), []byte(fmt.Sprint(i)+"\n"), 0664)
+			os.WriteFile(filepath.Join(cpudir, packageIdFile), []byte(fmt.Sprint(pkg)+"\n"), 0o664)
+			os.WriteFile(filepath.Join(cpudir, dieIdFile), []byte(fmt.Sprint(die)+"\n"), 0o664)
+			os.WriteFile(filepath.Join(cpudir, coreIdFile), []byte(fmt.Sprint(i)+"\n"), 0o664)
 		}
 		for prop, value := range cpufiles {
 			switch prop {
 			case "driver":
-				os.WriteFile(filepath.Join(cpudir, pStatesDrvFile), []byte(value+"\n"), 0664)
+				os.WriteFile(filepath.Join(cpudir, pStatesDrvFile), []byte(value+"\n"), 0o664)
 			case "max":
-				os.WriteFile(filepath.Join(cpudir, scalingMaxFile), []byte(value+"\n"), 0644)
-				os.WriteFile(filepath.Join(cpudir, cpuMaxFreqFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, scalingMaxFile), []byte(value+"\n"), 0o644)
+				os.WriteFile(filepath.Join(cpudir, cpuMaxFreqFile), []byte(value+"\n"), 0o644)
 			case "min":
-				os.WriteFile(filepath.Join(cpudir, scalingMinFile), []byte(value+"\n"), 0644)
-				os.WriteFile(filepath.Join(cpudir, cpuMinFreqFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, scalingMinFile), []byte(value+"\n"), 0o644)
+				os.WriteFile(filepath.Join(cpudir, cpuMinFreqFile), []byte(value+"\n"), 0o644)
 			case "epp":
-				os.WriteFile(filepath.Join(cpudir, eppFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, eppFile), []byte(value+"\n"), 0o644)
 			case "governor":
-				os.WriteFile(filepath.Join(cpudir, scalingGovFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, scalingGovFile), []byte(value+"\n"), 0o644)
 			case "available_governors":
-				os.WriteFile(filepath.Join(cpudir, availGovFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, availGovFile), []byte(value+"\n"), 0o644)
 			case "uncore_max":
-				os.WriteFile(filepath.Join(uncoreDir, pkgDir, uncoreInitMaxFreqFile), []byte(value+"\n"), 0644)
-				os.WriteFile(filepath.Join(uncoreDir, pkgDir, uncoreMaxFreqFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(uncoreDir, pkgDir, uncoreInitMaxFreqFile), []byte(value+"\n"), 0o644)
+				os.WriteFile(filepath.Join(uncoreDir, pkgDir, uncoreMaxFreqFile), []byte(value+"\n"), 0o644)
 			case "uncore_min":
-				os.WriteFile(filepath.Join(uncoreDir, pkgDir, uncoreInitMinFreqFile), []byte(value+"\n"), 0644)
-				os.WriteFile(filepath.Join(uncoreDir, pkgDir, uncoreMinFreqFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(uncoreDir, pkgDir, uncoreInitMinFreqFile), []byte(value+"\n"), 0o644)
+				os.WriteFile(filepath.Join(uncoreDir, pkgDir, uncoreMinFreqFile), []byte(value+"\n"), 0o644)
 			case "cstates":
 				for i, stateInfo := range cstates {
 					statedir := "cpuidle/state" + fmt.Sprint(i)
 					os.MkdirAll(filepath.Join(cpudir, statedir), os.ModePerm)
 					os.MkdirAll(filepath.Join(path, "cpuidle"), os.ModePerm)
-					os.WriteFile(filepath.Join(path, "cpuidle", "current_driver"), []byte(value+"\n"), 0644)
-					os.WriteFile(filepath.Join(cpudir, statedir, "name"), []byte(stateInfo["name"]+"\n"), 0644)
-					os.WriteFile(filepath.Join(cpudir, statedir, "disable"), []byte("0\n"), 0644)
-					os.WriteFile(filepath.Join(cpudir, statedir, "latency"), []byte(stateInfo["latency"]+"\n"), 0644)
-					os.WriteFile(filepath.Join(cpudir, statedir, "default_status"), []byte(stateInfo["default_status"]+"\n"), 0644)
+					os.WriteFile(filepath.Join(path, "cpuidle", "current_driver"), []byte(value+"\n"), 0o644)
+					os.WriteFile(filepath.Join(cpudir, statedir, "name"), []byte(stateInfo["name"]+"\n"), 0o644)
+					os.WriteFile(filepath.Join(cpudir, statedir, "disable"), []byte("0\n"), 0o644)
+					os.WriteFile(filepath.Join(cpudir, statedir, "latency"), []byte(stateInfo["latency"]+"\n"), 0o644)
+					os.WriteFile(filepath.Join(cpudir, statedir, "default_status"), []byte(stateInfo["default_status"]+"\n"), 0o644)
 				}
 			}
 
@@ -653,11 +652,11 @@ type errClient struct {
 	mock.Mock
 }
 
-func (e *errClient) Get(ctx context.Context, NamespacedName types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+func (e *errClient) Get(ctx context.Context, namespacedName types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
 	if len(opts) != 0 {
-		return e.Called(ctx, NamespacedName, obj, opts).Error(0)
+		return e.Called(ctx, namespacedName, obj, opts).Error(0)
 	}
-	return e.Called(ctx, NamespacedName, obj).Error(0)
+	return e.Called(ctx, namespacedName, obj).Error(0)
 }
 func (e *errClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	if len(opts) != 0 {

--- a/controllers/uncore_controller.go
+++ b/controllers/uncore_controller.go
@@ -300,8 +300,8 @@ func (r *UncoreReconciler) updateUncoreInPowerNodeState(
 
 	patchNodeState := &powerv1alpha1.PowerNodeState{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "power.cluster-power-manager.github.io/v1alpha1",
-			Kind:       "PowerNodeState",
+			APIVersion: powerv1alpha1.GroupVersion.String(),
+			Kind:       PowerNodeStateKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      powerNodeStateName,
@@ -336,8 +336,8 @@ func (r *UncoreReconciler) removeUncoreFromPowerNodeState(ctx context.Context, n
 
 	patchNodeState := &powerv1alpha1.PowerNodeState{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "power.cluster-power-manager.github.io/v1alpha1",
-			Kind:       "PowerNodeState",
+			APIVersion: powerv1alpha1.GroupVersion.String(),
+			Kind:       PowerNodeStateKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      powerNodeStateName,

--- a/internal/scaling/dpdk_client_test.go
+++ b/internal/scaling/dpdk_client_test.go
@@ -339,9 +339,7 @@ func TestDPDKConnection_connectLoop(t *testing.T) {
 	dpdkConn := createNewDPDKConnection()
 	ctx, cancel := context.WithCancel(context.TODO())
 	t.Cleanup(cancel)
-	var conn net.Conn = nil
-
-	conn = dpdkConn.connectLoop(ctx)
+	conn := dpdkConn.connectLoop(ctx)
 
 	assert.NotNil(t, conn)
 }
@@ -434,7 +432,7 @@ func TestDPDKConnection_processCommand(t *testing.T) {
 				c.AssertCalled(t, "SetWriteDeadline", timeout)
 				c.AssertCalled(t, "Write", commandBytes)
 				c.AssertCalled(t, "SetReadDeadline", timeout)
-				// Anything is used here instead of AnythingOfType beacuse assert
+				// Anything is used here instead of AnythingOfType because assert
 				// still makes a distinction between filled and empty slice.
 				c.AssertCalled(t, "Read", mock.Anything)
 			},
@@ -455,7 +453,7 @@ func TestDPDKConnection_processCommand(t *testing.T) {
 				c.AssertCalled(t, "SetWriteDeadline", timeout)
 				c.AssertCalled(t, "Write", commandBytes)
 				c.AssertCalled(t, "SetReadDeadline", timeout)
-				// Anything is used here instead of AnythingOfType beacuse assert
+				// Anything is used here instead of AnythingOfType because assert
 				// still makes a distinction between filled and empty slice.
 				c.AssertCalled(t, "Read", mock.Anything)
 			},
@@ -483,7 +481,7 @@ func TestDPDKConnection_processCommand(t *testing.T) {
 				c.AssertCalled(t, "SetWriteDeadline", timeout)
 				c.AssertCalled(t, "Write", commandBytes)
 				c.AssertCalled(t, "SetReadDeadline", timeout)
-				// Anything is used here instead of AnythingOfType beacuse assert
+				// Anything is used here instead of AnythingOfType because assert
 				// still makes a distinction between filled and empty slice.
 				c.AssertCalled(t, "Read", mock.Anything)
 			},

--- a/internal/scaling/test_common.go
+++ b/internal/scaling/test_common.go
@@ -45,28 +45,28 @@ func setupScalingTestFiles(cores int, cpufiles map[string]string) (power.Host, f
 		for prop, value := range fileMap {
 			switch prop {
 			case "driver":
-				os.WriteFile(filepath.Join(cpudir, pStatesDrvFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, pStatesDrvFile), []byte(value+"\n"), 0o644)
 			case "governor":
-				os.WriteFile(filepath.Join(cpudir, scalingGovFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, scalingGovFile), []byte(value+"\n"), 0o644)
 			case "setspeed":
-				os.WriteFile(filepath.Join(cpudir, scalingSetSpeedFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, scalingSetSpeedFile), []byte(value+"\n"), 0o644)
 			case "current":
-				os.WriteFile(filepath.Join(cpudir, scalingCurFreqFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, scalingCurFreqFile), []byte(value+"\n"), 0o644)
 			case "max":
-				os.WriteFile(filepath.Join(cpudir, scalingMaxFile), []byte(value+"\n"), 0644)
-				os.WriteFile(filepath.Join(cpudir, cpuMaxFreqFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, scalingMaxFile), []byte(value+"\n"), 0o644)
+				os.WriteFile(filepath.Join(cpudir, cpuMaxFreqFile), []byte(value+"\n"), 0o644)
 			case "min":
-				os.WriteFile(filepath.Join(cpudir, scalingMinFile), []byte(value+"\n"), 0644)
-				os.WriteFile(filepath.Join(cpudir, cpuMinFreqFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, scalingMinFile), []byte(value+"\n"), 0o644)
+				os.WriteFile(filepath.Join(cpudir, cpuMinFreqFile), []byte(value+"\n"), 0o644)
 			case "available_governors":
-				os.WriteFile(filepath.Join(cpudir, availGovFile), []byte(value+"\n"), 0644)
+				os.WriteFile(filepath.Join(cpudir, availGovFile), []byte(value+"\n"), 0o644)
 			}
 		}
 
 		// Minimal topology info
-		os.WriteFile(filepath.Join(cpudir, "topology", "physical_package_id"), []byte("0\n"), 0664)
-		os.WriteFile(filepath.Join(cpudir, "topology", "die_id"), []byte("0\n"), 0664)
-		os.WriteFile(filepath.Join(cpudir, "topology", "core_id"), []byte(fmt.Sprint(i)+"\n"), 0664)
+		os.WriteFile(filepath.Join(cpudir, "topology", "physical_package_id"), []byte("0\n"), 0o664)
+		os.WriteFile(filepath.Join(cpudir, "topology", "die_id"), []byte("0\n"), 0o664)
+		os.WriteFile(filepath.Join(cpudir, "topology", "core_id"), []byte(fmt.Sprint(i)+"\n"), 0o664)
 	}
 
 	// Create power library instance with custom CPU path

--- a/internal/scaling/updater_test.go
+++ b/internal/scaling/updater_test.go
@@ -313,9 +313,9 @@ func TestCPUScalingUpdater_Update(t *testing.T) {
 			setFreqpath := filepath.Join("testing", "cpus", fmt.Sprintf("cpu%d", tc.cpuID), "cpufreq", "scaling_setspeed")
 
 			// Set current frequency and clear setspeed file
-			err = os.WriteFile(curFreqPath, []byte(tc.currentFreq+"\n"), 0644)
+			err = os.WriteFile(curFreqPath, []byte(tc.currentFreq+"\n"), 0o644)
 			assert.NoError(t, err)
-			err = os.WriteFile(setFreqpath, []byte(""), 0644)
+			err = os.WriteFile(setFreqpath, []byte(""), 0o644)
 			assert.NoError(t, err)
 
 			dpdkmock := &MockDPDKTelemetryClient{}

--- a/pkg/cpuset/cpuset.go
+++ b/pkg/cpuset/cpuset.go
@@ -165,14 +165,14 @@ func (s *CPUSet) UnionAll(s2 []CPUSet) CPUSet {
 // that are present in both this set and the supplied set, without mutating
 // either source set.
 func (s *CPUSet) Intersection(s2 CPUSet) CPUSet {
-	return s.Filter(func(cpu int) bool { return s2.Contains(cpu) })
+	return s.Filter(s2.Contains)
 }
 
 // Difference returns a new CPU set that contains all of the elements that
 // are present in this set and not the supplied set, without mutating either
 // source set.
 func (s *CPUSet) Difference(s2 CPUSet) CPUSet {
-	return s.FilterNot(func(cpu int) bool { return s2.Contains(cpu) })
+	return s.FilterNot(s2.Contains)
 }
 
 // ToSlice returns a slice of integers that contains all elements from
@@ -253,7 +253,8 @@ func (s *CPUSet) String() string {
 		if r.start == r.end {
 			result.WriteString(strconv.Itoa(r.start))
 		} else {
-			result.WriteString(fmt.Sprintf("%d-%d", r.start, r.end))
+			rangeString := fmt.Sprintf("%d-%d", r.start, r.end)
+			result.WriteString(rangeString)
 		}
 		result.WriteString(",")
 	}

--- a/pkg/cpuset/cpuset_test.go
+++ b/pkg/cpuset/cpuset_test.go
@@ -71,12 +71,12 @@ func areSlicesEqualInt64(sliceA, sliceB []int64) bool {
 	return true
 }
 
-//Tests
+// Tests
 
 func TestNewBuilder(t *testing.T) {
 	builder := NewBuilder()
 
-	//Assert that the elemennt map is initialised ant not nil
+	// Assert that the element map is initialised and not nil
 	if builder.result.elems == nil {
 		t.Errorf("Expected elems map to be initialized, but it was nil")
 	}
@@ -107,7 +107,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestResult(t *testing.T) {
-	//Test case -- Test with elements added
+	// Test case -- Test with elements added
 	builderA := NewBuilder()
 	builderA.Add(1, 2, 3)
 
@@ -122,7 +122,7 @@ func TestResult(t *testing.T) {
 	}
 
 	assert.True(t, expectedA.Equals(cpuSetA))
-	//Test case -- Test builder is marked "done"
+	// Test case -- Test builder is marked "done"
 	builderB := NewBuilder()
 	builderB.Result()
 
@@ -130,7 +130,7 @@ func TestResult(t *testing.T) {
 		t.Error("Expected: Builder to be marked 'done'. Actual: Builder not marked 'done'.")
 	}
 
-	//Test case -- Checks Adds dont effect result
+	// Test case -- Checks Adds dont effect result
 	builderC := NewBuilder()
 	builderC.Result()
 	builderC.Add(4)
@@ -141,17 +141,17 @@ func TestResult(t *testing.T) {
 }
 
 func TestNewCPUSet(t *testing.T) {
-	//Test case -- Create a CPUSet with elements
+	// Test case -- Create a CPUSet with elements
 	cpusetA := NewCPUSet(1, 2, 3)
 
-	//Checks elemnts are present
+	// Checks elemnts are present
 	for i := 1; i <= 3; i++ {
 		if _, found := cpusetA.elems[i]; !found {
 			t.Errorf("Expected: Element %d in CPUSet. Actual: Element was not found", i)
 		}
 	}
 
-	//Test case -- Create a CPUSet with single element
+	// Test case -- Create a CPUSet with single element
 	cpusetB := NewCPUSet(10)
 
 	if _, found := cpusetB.elems[10]; !found {
@@ -166,7 +166,7 @@ func TestNewCPUSet(t *testing.T) {
 }
 
 func TestSize(t *testing.T) {
-	//Test case -- Size of empty set
+	// Test case -- Size of empty set
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -174,7 +174,7 @@ func TestSize(t *testing.T) {
 	sizeA := cpusetA.Size()
 	assert.Equal(t, 0, sizeA)
 
-	//Test case -- Size of a non-empty set
+	// Test case -- Size of a non-empty set
 	cpusetB := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -188,14 +188,14 @@ func TestSize(t *testing.T) {
 }
 
 func TestIsEmpty(t *testing.T) {
-	//Test case -- Empty CPUSet
+	// Test case -- Empty CPUSet
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{},
 	}
 
 	assert.True(t, cpusetA.IsEmpty())
 
-	//Test case -- Non-empty set
+	// Test case -- Non-empty set
 	cpusetB := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -208,7 +208,7 @@ func TestIsEmpty(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
-	//Test case -- CPUSet contains the element
+	// Test case -- CPUSet contains the element
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -221,7 +221,7 @@ func TestContains(t *testing.T) {
 		t.Errorf("Expected: Set contains element 1. Actual: Element 1 not found in set")
 	}
 
-	//Test case -- Non-empty set
+	// Test case -- Non-empty set
 	cpusetB := &CPUSet{
 		elems: map[int]struct{}{
 			4: {},
@@ -236,7 +236,7 @@ func TestContains(t *testing.T) {
 }
 
 func TestEquals(t *testing.T) {
-	//Test case -- Two equal sets
+	// Test case -- Two equal sets
 	cpusetA := CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -255,7 +255,7 @@ func TestEquals(t *testing.T) {
 
 	assert.True(t, cpusetA.Equals(cpusetB))
 
-	//Test case -- Two unequals
+	// Test case -- Two unequals
 	cpusetX := CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -275,7 +275,7 @@ func TestEquals(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	//Test case: Filter even numbers
+	// Test case: Filter even numbers
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -300,7 +300,7 @@ func TestFilter(t *testing.T) {
 		t.Error(("Expected: even number 2 found. Actual: 2 has been filtered out"))
 	}
 
-	//Test case: Filter numbers smaller than 4
+	// Test case: Filter numbers smaller than 4
 	cpusetB := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -331,7 +331,7 @@ func TestFilter(t *testing.T) {
 }
 
 func TestFilterNot(t *testing.T) {
-	//Test case: Filter even numbers
+	// Test case: Filter even numbers
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -356,7 +356,7 @@ func TestFilterNot(t *testing.T) {
 		t.Error(("Expected: even number 2 filtered out. Actual: 2 has not been filtered out"))
 	}
 
-	//Test case: Filter numbers smaller than 4
+	// Test case: Filter numbers smaller than 4
 	cpusetB := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -387,7 +387,7 @@ func TestFilterNot(t *testing.T) {
 }
 
 func TestSubsetOf(t *testing.T) {
-	//Test case -- Empty set is a subset of any set
+	// Test case -- Empty set is a subset of any set
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -399,7 +399,7 @@ func TestSubsetOf(t *testing.T) {
 		t.Error("Expected: Empty set to be a subset of any set. Actual: It was not")
 	}
 
-	//Test case -- Proper subset
+	// Test case -- Proper subset
 	cpusetJ := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -418,7 +418,7 @@ func TestSubsetOf(t *testing.T) {
 		t.Error("Expected: SetJ is a subset of setK. Actual: It was not a subset")
 	}
 
-	//Test case -- Empty set is a subset of any set
+	// Test case -- Empty set is a subset of any set
 	cpusetX := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -440,7 +440,7 @@ func TestSubsetOf(t *testing.T) {
 
 func TestUnion(t *testing.T) {
 
-	//Test case -- Two empty
+	// Test case -- Two empty
 	cpusetA := CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -455,7 +455,7 @@ func TestUnion(t *testing.T) {
 	unionA := cpusetA.Union(cpusetB)
 	assert.True(t, expectedA.Equals(unionA))
 
-	//Test case -- One empty, one with two elements
+	// Test case -- One empty, one with two elements
 	cpusetX := CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -478,7 +478,7 @@ func TestUnion(t *testing.T) {
 }
 
 func TestUnionAll(t *testing.T) {
-	//Test case -- Empty set union with empty slices should result in an empty set
+	// Test case -- Empty set union with empty slices should result in an empty set
 	cpusetA := CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -492,7 +492,7 @@ func TestUnionAll(t *testing.T) {
 
 	assert.True(t, expectedA.Equals(union_allA))
 
-	//Test case -- Non-empty set union with non-empty sets
+	// Test case -- Non-empty set union with non-empty sets
 	cpusetJ := CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -542,7 +542,7 @@ func TestIntersection(t *testing.T) {
 	intersectionA := cpusetA.Intersection(cpusetB)
 	assert.True(t, expectedA.Equals(intersectionA))
 
-	//Test case -- Non empty set intersects with an empty should produce empty
+	// Test case -- Non empty set intersects with an empty should produce empty
 	cpusetJ := CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -560,7 +560,7 @@ func TestIntersection(t *testing.T) {
 	intersectionB := cpusetJ.Intersection(cpusetK)
 	assert.True(t, expectedB.Equals(intersectionB))
 
-	//Test case -- Non-empty set intersects with another non-empty set
+	// Test case -- Non-empty set intersects with another non-empty set
 	cpusetX := CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -588,7 +588,7 @@ func TestIntersection(t *testing.T) {
 }
 
 func TestDifference(t *testing.T) {
-	//Test case -- Empty set intersection with another empty set should result in an empty set
+	// Test case -- Empty set intersection with another empty set should result in an empty set
 	cpusetA := CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -601,7 +601,7 @@ func TestDifference(t *testing.T) {
 
 	differenceA := cpusetA.Difference(cpusetB)
 	assert.True(t, expectedA.Equals(differenceA))
-	//Test case -- Non empty set difference with an empty should produce non-empty
+	// Test case -- Non empty set difference with an empty should produce non-empty
 	cpusetJ := CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -623,7 +623,7 @@ func TestDifference(t *testing.T) {
 }
 
 func TestToSlice(t *testing.T) {
-	//Test case -- Empty set should return empty slice
+	// Test case -- Empty set should return empty slice
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -632,7 +632,7 @@ func TestToSlice(t *testing.T) {
 		t.Error("Expected: Empty slice. Actual: Non-empty slice")
 	}
 
-	//Test case -- Non-empty should sort and return slice
+	// Test case -- Non-empty should sort and return slice
 	cpusetB := &CPUSet{
 		elems: map[int]struct{}{
 			4: {},
@@ -650,7 +650,7 @@ func TestToSlice(t *testing.T) {
 }
 
 func TestToSliceNoSort(t *testing.T) {
-	//Test case -- Empty set should return empty slice
+	// Test case -- Empty set should return empty slice
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -659,7 +659,7 @@ func TestToSliceNoSort(t *testing.T) {
 		t.Error("Expected: Empty slice. Actual: Non-empty slice")
 	}
 
-	//Test case -- Non-empty should sort and return slice
+	// Test case -- Non-empty should sort and return slice
 	cpusetB := &CPUSet{
 		elems: map[int]struct{}{
 			4: {},
@@ -678,14 +678,14 @@ func TestToSliceNoSort(t *testing.T) {
 }
 
 func TestToSliceInt64(t *testing.T) {
-	//Test case -- Empty set should return empty slice
+	// Test case -- Empty set should return empty slice
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{},
 	}
 	sliceA := cpusetA.ToSliceInt64()
 	assert.Nil(t, sliceA)
 
-	//Test case -- Non-empty should sort and return slice
+	// Test case -- Non-empty should sort and return slice
 	cpusetB := &CPUSet{
 		elems: map[int]struct{}{
 			4: {},
@@ -703,7 +703,7 @@ func TestToSliceInt64(t *testing.T) {
 
 func TestToSliceNoSortInt64(t *testing.T) {
 
-	//Test case -- Empty set should return empty slice
+	// Test case -- Empty set should return empty slice
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -713,7 +713,7 @@ func TestToSliceNoSortInt64(t *testing.T) {
 	sliceA := cpusetA.ToSliceNoSortInt64()
 	assert.True(t, areSlicesEqualInt64(sliceA, expectedSliceA))
 
-	//Test case -- Non-empty should sort and return slice
+	// Test case -- Non-empty should sort and return slice
 	cpusetB := &CPUSet{
 		elems: map[int]struct{}{
 			4: {},
@@ -730,7 +730,7 @@ func TestToSliceNoSortInt64(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	//Test case -- Empty set should return an empty string
+	// Test case -- Empty set should return an empty string
 	cpusetA := &CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -740,7 +740,7 @@ func TestString(t *testing.T) {
 	resultA := cpusetA.String()
 	assert.Equal(t, expectedStringA, resultA)
 
-	//Test case -- Non-empty set with consecutive elements should return string with ranges
+	// Test case -- Non-empty set with consecutive elements should return string with ranges
 	cpusetB := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -757,7 +757,7 @@ func TestString(t *testing.T) {
 	resultB := cpusetB.String()
 	assert.Equal(t, expectedStringB, resultB)
 
-	//Test case -- Non-empty set with non-consecutive elements should return string with individual elements
+	// Test case -- Non-empty set with non-consecutive elements should return string with individual elements
 	cpusetC := &CPUSet{
 		elems: map[int]struct{}{
 			1: {},
@@ -773,7 +773,7 @@ func TestString(t *testing.T) {
 }
 
 func TestMustParse(t *testing.T) {
-	//Test case -- Valid string parsed
+	// Test case -- Valid string parsed
 	inputStrA := "1,2,3,5-7,10"
 	expectedA := CPUSet{
 		elems: map[int]struct{}{
@@ -792,7 +792,7 @@ func TestMustParse(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
-	//Test case -- Valid string parsed
+	// Test case -- Valid string parsed
 	inputStrA := ""
 	expectedA := CPUSet{
 		elems: map[int]struct{}{},
@@ -802,7 +802,7 @@ func TestParse(t *testing.T) {
 	assert.NoError(t, errA)
 	assert.Equal(t, expectedA, resultA)
 
-	//Test case -- Single elements seperated by commas
+	// Test case -- Single elements separated by commas
 	inputStrB := "1,3,5,7"
 	expectedB := CPUSet{
 		elems: map[int]struct{}{
@@ -817,7 +817,7 @@ func TestParse(t *testing.T) {
 	assert.NoError(t, errB)
 	assert.Equal(t, expectedB, resultB)
 
-	//Test case -- Range of elemenst
+	// Test case -- Range of elemenst
 	inputStrC := "1-4,6,8-9"
 	expectedC := CPUSet{
 		elems: map[int]struct{}{
@@ -837,7 +837,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
-	//Test case -- Empty set should return empty
+	// Test case -- Empty set should return empty
 	cpusetA := CPUSet{
 		elems: map[int]struct{}{},
 	}
@@ -845,7 +845,7 @@ func TestClone(t *testing.T) {
 	cloneA := cpusetA.Clone()
 	assert.True(t, cpusetA.Equals(cloneA))
 
-	//Test case -- Non-Empty set should return mom-empty
+	// Test case -- Non-Empty set should return mom-empty
 	cpusetB := CPUSet{
 		elems: map[int]struct{}{
 			1: {},

--- a/pkg/podresourcesclient/podresourcesclient.go
+++ b/pkg/podresourcesclient/podresourcesclient.go
@@ -58,17 +58,17 @@ func newClient(socket string) (*PodResourcesClient, error) {
 func getV1Client(socket string, connectionTimeout time.Duration, maxMsgSize int) (podresourcesapi.PodResourcesListerClient, *grpc.ClientConn, error) {
 	addr, dialer, err := util.GetAddressAndDialer(socket)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error getting address and dialer for socket %s: %v", socket, err)
+		return nil, nil, fmt.Errorf("error getting address and dialer for socket %s: %w", socket, err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
 	defer cancel()
 
-	conn, err := grpc.DialContext(ctx, addr,
+	conn, err := grpc.DialContext(ctx, addr, //nolint:staticcheck // SA1019: TODO: migrate to grpc.NewClient changes connection semantics
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(dialer),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
 	if err != nil {
-		return nil, nil, fmt.Errorf("error dialing socket %s: %v", socket, err)
+		return nil, nil, fmt.Errorf("error dialing socket %s: %w", socket, err)
 	}
 	return podresourcesapi.NewPodResourcesListerClient(conn), conn, nil
 }
@@ -88,7 +88,7 @@ func (p *PodResourcesClient) listResources(controlPlaneClient bool) (*podresourc
 	// only default client errs are logged as controlplane socket isn't guaranteed to be there
 	// otherwise we'd be spamming the logs in static cpu policy deployments
 	if err != nil && clientType == "default" {
-		return nil, fmt.Errorf("can't receive response from %s client: %v", clientType, err)
+		return nil, fmt.Errorf("can't receive response from %s client: %w", clientType, err)
 	}
 	return resp, nil
 }

--- a/pkg/podresourcesclient/podresourcesclient_test.go
+++ b/pkg/podresourcesclient/podresourcesclient_test.go
@@ -3,10 +3,11 @@ package podresourcesclient
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
-	"testing"
 )
 
 type fakePodResourcesClient struct {

--- a/pkg/podstate/podstate_test.go
+++ b/pkg/podstate/podstate_test.go
@@ -11,18 +11,14 @@ import (
 func TestNewState(t *testing.T) {
 	state, err := NewState()
 
-	//Test case -- verifying that no error is returned
+	// Test case -- verifying that no error is returned
 	assert.Nil(t, err)
 
-	//Test case -- verifying that a state object is returned
-	if state == nil {
-		t.Errorf("Expected a State object, but got nil")
-	}
+	// Test case -- verifying that a state object is returned
+	assert.NotNil(t, state, "Expected a State object, but got nil")
 
-	//Test case -- verifying that the GuaranteedPods slice is empty
-	if len(state.GuaranteedPods) != 0 {
-		t.Errorf("Expected GuaranteedPods to be empty, but got %v", state.GuaranteedPods)
-	}
+	// Test case -- verifying that the GuaranteedPods slice is empty
+	assert.Empty(t, state.GuaranteedPods, "Expected GuaranteedPods to be empty")
 }
 
 func TestUpdateStateGuaranteedPods(t *testing.T) {
@@ -34,19 +30,19 @@ func TestUpdateStateGuaranteedPods(t *testing.T) {
 		},
 	}
 
-	//Test case -- updating an existing pod
+	// Test case -- updating an existing pod
 	err := state.UpdateStateGuaranteedPods(powerv1alpha1.GuaranteedPod{Name: "pod2"})
 	assert.Nil(t, err)
 	assert.Equal(t, state.GuaranteedPods[1].Name, "pod2")
 
-	//Test case -- adding a new pod
+	// Test case -- adding a new pod
 	err = state.UpdateStateGuaranteedPods(powerv1alpha1.GuaranteedPod{Name: "pod4"})
 	assert.Nil(t, err)
 	assert.Equal(t, state.GuaranteedPods[len(state.GuaranteedPods)-1].Name, "pod4")
 }
 
 func TestGetPodFromState(t *testing.T) {
-	//Test case -- a state instance with some sample data
+	// Test case -- a state instance with some sample data
 	state := &State{
 		GuaranteedPods: []powerv1alpha1.GuaranteedPod{
 			{Name: "pod1"},
@@ -54,12 +50,12 @@ func TestGetPodFromState(t *testing.T) {
 		},
 	}
 
-	//Test case -- Existing pod in the state
+	// Test case -- Existing pod in the state
 	existingPodName := "pod1"
 	existingPod := state.GetPodFromState(existingPodName, "")
 	assert.Equal(t, existingPodName, existingPod.Name)
 
-	//Test case -- Non-Existing pod in the state
+	// Test case -- Non-Existing pod in the state
 	nonExistingPodName := "pod4"
 	nonExistingPod := state.GetPodFromState(nonExistingPodName, "")
 	if !reflect.DeepEqual(nonExistingPod, powerv1alpha1.GuaranteedPod{}) {
@@ -68,7 +64,7 @@ func TestGetPodFromState(t *testing.T) {
 }
 
 func TestGetCPUsFromPodState(t *testing.T) {
-	//Test case -- sample pod state with two containers
+	// Test case -- sample pod state with two containers
 	podState := powerv1alpha1.GuaranteedPod{
 		Containers: []powerv1alpha1.Container{
 			{ExclusiveCPUs: []uint{1, 2}},
@@ -76,7 +72,7 @@ func TestGetCPUsFromPodState(t *testing.T) {
 		},
 	}
 
-	//Creating a state instance
+	// Creating a state instance
 	state := &State{}
 	cpus := state.GetCPUsFromPodState(podState)
 	expectedCPUs := []uint{1, 2, 3}
@@ -86,7 +82,7 @@ func TestGetCPUsFromPodState(t *testing.T) {
 }
 
 func TestDeletePodFromState(t *testing.T) {
-	//Create a state instance with some sample data
+	// Create a state instance with some sample data
 
 	state := &State{
 		GuaranteedPods: []powerv1alpha1.GuaranteedPod{
@@ -95,7 +91,7 @@ func TestDeletePodFromState(t *testing.T) {
 		},
 	}
 
-	//Test case: Delteing an existing pod
+	// Test case: Delteing an existing pod
 	podToDelete := "pod1"
 	err := state.DeletePodFromState(podToDelete, "")
 	assert.Nil(t, err)
@@ -106,7 +102,7 @@ func TestDeletePodFromState(t *testing.T) {
 		}
 	}
 
-	//Test case -- Deleting a non-existing pod
+	// Test case -- Deleting a non-existing pod
 	nonExistingPodState := "pod3"
 	err = state.DeletePodFromState(nonExistingPodState, "")
 	assert.Nil(t, err)

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -26,11 +26,6 @@ func TestNewPowerNodeData(t *testing.T) {
 	expected := []string{}
 	assert.Equal(t, powerNodeData.PowerNodeList, expected, "PowerNodeList field is not empty.")
 
-	//making sure that list contains only newly added node
-	for i := 0; i < len(expected); i++ {
-		assert.Equal(t, powerNodeData.PowerNodeList, expected, "PowerNodeList field is not empty.")
-		break
-	}
 }
 
 func TestUpdatePowerNodeData(t *testing.T) {
@@ -59,10 +54,10 @@ func TestUpdatePowerNodeData(t *testing.T) {
 
 func TestDeletePowerNodeData(t *testing.T) {
 	testData := &PowerNodeData{
-		PowerNodeList: []string{"node1", "node2", "node3"}, //generic nodes
+		PowerNodeList: []string{"node1", "node2", "node3"}, // generic nodes
 	}
 
-	testData.DeletePowerNodeData("node2") //deleting node2
+	testData.DeletePowerNodeData("node2") // deleting node2
 
 	expected := []string{"node1", "node3"}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,11 +18,13 @@ package util
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 	"net"
 	"net/url"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -116,14 +118,14 @@ func UnpackErrsToStrings(err error) *[]string {
 		return &[]string{}
 	}
 
-	switch joinedErr := err.(type) {
-	case interface{ Unwrap() []error }:
-		stringErrs := make([]string, len(joinedErr.Unwrap()))
-		for i, individualErr := range joinedErr.Unwrap() {
+	var joinedErr interface{ Unwrap() []error }
+	if errors.As(err, &joinedErr) {
+		errs := joinedErr.Unwrap()
+		stringErrs := make([]string, len(errs))
+		for i, individualErr := range errs {
 			stringErrs[i] = individualErr.Error()
 		}
 		return &stringErrs
-	default:
-		return &[]string{err.Error()}
 	}
+	return &[]string{err.Error()}
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -365,14 +365,14 @@ func TestUnpackErrsToStrings(t *testing.T) {
 
 	// single error
 	const errString1 = "err1"
-	assert.Equal(t, UnpackErrsToStrings(fmt.Errorf(errString1)), &[]string{errString1})
+	assert.Equal(t, &[]string{errString1}, UnpackErrsToStrings(errors.New(errString1)))
 
 	// wrapped err
 	const errString2 = "err2"
 	assert.Equal(
 		t,
-		UnpackErrsToStrings(errors.Join(fmt.Errorf(errString1), fmt.Errorf(errString2))),
 		&[]string{errString1, errString2},
+		UnpackErrsToStrings(errors.Join(errors.New(errString1), errors.New(errString2))),
 	)
 
 }


### PR DESCRIPTION
Add linting to the CI pipeline using golangci-lint v2. The Makefile downloads and manages the linter binary, ensuring CI and local dev use the same version. Enables a set of commonly used linters for Go projects covering code correctness, security, and style.

Fix all existing lint violations so the CI job passes cleanly.