### PR TITLE
Enable gocyclo linter and reduce cyclomatic complexity

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,7 +8,7 @@ linters:
     - gocritic       # code style, diagnostics, and performance checks
     - govet          # go vet checks
     - gosec          # security checks
-    # - gocyclo      # TODO: cyclomatic complexity
+    - gocyclo        # cyclomatic complexity
     - ineffassign    # unused variable assignments
     - staticcheck    # comprehensive static analysis
     - unused         # unused code detection

--- a/controllers/powerpod_controller.go
+++ b/controllers/powerpod_controller.go
@@ -99,56 +99,7 @@ func (r *PowerPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	nodeName := os.Getenv("NODE_NAME")
 
 	if !pod.ObjectMeta.DeletionTimestamp.IsZero() || pod.Status.Phase == corev1.PodSucceeded {
-		// If the pod's deletion timestamp is not zero, then the pod has been deleted
-
-		// Delete the Pod from the internal state in case it was never deleted
-		_ = r.State.DeletePodFromState(pod.GetName(), pod.GetNamespace())
-
-		// Get the pod's CPU assignments from PowerNodeState to know what to clean up.
-		powerNodeStateName := fmt.Sprintf("%s-power-state", nodeName)
-		currentNodeState := &powerv1alpha1.PowerNodeState{}
-
-		// Get the PowerNodeState to find this pod's CPU assignments and move them back to the shared pool.
-		err = r.Get(ctx, client.ObjectKey{Namespace: PowerNamespace, Name: powerNodeStateName}, currentNodeState)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				logger.Info("WARNING: PowerNodeState not found during pod deletion, CPUs may remain in exclusive pool", "powerNodeState", powerNodeStateName)
-			} else {
-				logger.Error(err, "failed to get PowerNodeState")
-				return ctrl.Result{}, err
-			}
-		} else if currentNodeState.Status.CPUPools != nil {
-			// Move the pod's CPUs back to the shared pool.
-			var deletedCPUIDs []uint
-			for _, exclusive := range currentNodeState.Status.CPUPools.Exclusive {
-				if exclusive.PodUID == string(pod.GetUID()) {
-					for _, container := range exclusive.PowerContainers {
-						logger.V(5).Info("moving CPUs back to shared pool", "container", container.Name, "profile", container.PowerProfile, "cpus", container.CPUIDs)
-						if err := r.PowerLibrary.GetSharedPool().MoveCpuIDs(container.CPUIDs); err != nil {
-							logger.Error(err, "failed to move CPUs back to shared pool", "container", container.Name, "profile", container.PowerProfile)
-							return ctrl.Result{}, err
-						}
-						deletedCPUIDs = append(deletedCPUIDs, container.CPUIDs...)
-					}
-					break
-				}
-			}
-
-			// Tear down DPDK telemetry and scaling for this pod's CPUs.
-			// No-op for non-DPDK pods: CloseConnection and RemoveCPUScaling
-			// safely ignore entries that don't exist.
-			if r.DPDKTelemetryClient != nil && r.CPUScalingManager != nil {
-				r.DPDKTelemetryClient.CloseConnection(string(pod.GetUID()))
-				r.CPUScalingManager.RemoveCPUScaling(deletedCPUIDs)
-			}
-		}
-
-		// Remove the pod's entry from PowerNodeState via SSA.
-		if err := r.removePowerNodeStatusExclusiveEntry(ctx, nodeName, string(pod.GetUID()), &logger); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		return ctrl.Result{}, nil
+		return r.handlePodDeletion(ctx, pod, nodeName, &logger)
 	}
 
 	// If the pod's deletion timestamp is equal to zero, then the pod has been created or updated.
@@ -294,6 +245,60 @@ func (r *PowerPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		logger.Error(wrappedErrs, "recoverable errors")
 		return ctrl.Result{Requeue: false}, fmt.Errorf("recoverable errors encountered: %w", wrappedErrs)
 	}
+	return ctrl.Result{}, nil
+}
+
+// handlePodDeletion cleans up when a guaranteed pod is deleted or succeeded. It moves the pod's
+// exclusive CPUs back to the shared pool, tears down any DPDK telemetry/scaling, and removes
+// the pod's entry from PowerNodeState.
+func (r *PowerPodReconciler) handlePodDeletion(ctx context.Context, pod *corev1.Pod, nodeName string, logger *logr.Logger) (ctrl.Result, error) {
+	// Delete the Pod from the internal state in case it was never deleted
+	_ = r.State.DeletePodFromState(pod.GetName(), pod.GetNamespace())
+
+	// Get the pod's CPU assignments from PowerNodeState to know what to clean up.
+	powerNodeStateName := fmt.Sprintf("%s-power-state", nodeName)
+	currentNodeState := &powerv1alpha1.PowerNodeState{}
+
+	// Get the PowerNodeState to find this pod's CPU assignments and move them back to the shared pool.
+	err := r.Get(ctx, client.ObjectKey{Namespace: PowerNamespace, Name: powerNodeStateName}, currentNodeState)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("WARNING: PowerNodeState not found during pod deletion, CPUs may remain in exclusive pool", "powerNodeState", powerNodeStateName)
+		} else {
+			logger.Error(err, "failed to get PowerNodeState")
+			return ctrl.Result{}, err
+		}
+	} else if currentNodeState.Status.CPUPools != nil {
+		// Move the pod's CPUs back to the shared pool.
+		var deletedCPUIDs []uint
+		for _, exclusive := range currentNodeState.Status.CPUPools.Exclusive {
+			if exclusive.PodUID == string(pod.GetUID()) {
+				for _, container := range exclusive.PowerContainers {
+					logger.V(5).Info("moving CPUs back to shared pool", "container", container.Name, "profile", container.PowerProfile, "cpus", container.CPUIDs)
+					if err := r.PowerLibrary.GetSharedPool().MoveCpuIDs(container.CPUIDs); err != nil {
+						logger.Error(err, "failed to move CPUs back to shared pool", "container", container.Name, "profile", container.PowerProfile)
+						return ctrl.Result{}, err
+					}
+					deletedCPUIDs = append(deletedCPUIDs, container.CPUIDs...)
+				}
+				break
+			}
+		}
+
+		// Tear down DPDK telemetry and scaling for this pod's CPUs.
+		// No-op for non-DPDK pods: CloseConnection and RemoveCPUScaling
+		// safely ignore entries that don't exist.
+		if r.DPDKTelemetryClient != nil && r.CPUScalingManager != nil {
+			r.DPDKTelemetryClient.CloseConnection(string(pod.GetUID()))
+			r.CPUScalingManager.RemoveCPUScaling(deletedCPUIDs)
+		}
+	}
+
+	// Remove the pod's entry from PowerNodeState via SSA.
+	if err := r.removePowerNodeStatusExclusiveEntry(ctx, nodeName, string(pod.GetUID()), logger); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/powerprofile_controller.go
+++ b/controllers/powerprofile_controller.go
@@ -100,56 +100,7 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	logger.V(5).Info("retrieving the power profile instances")
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// First we need to remove the profile from the Power library, this will in turn remove the pool,
-			// which will also move the cores back to the Shared/Default pool and reconfigure them. We then
-			// need to remove the Power Workload from the cluster, which in this case will do nothing as
-			// everything has already been removed. Finally, we remove the Extended Resources from the Node
-			// first we make sure the profile isn't the one used by the shared pool
-			if r.PowerLibrary.GetSharedPool().GetPowerProfile() != nil && req.Name == r.PowerLibrary.GetSharedPool().GetPowerProfile().Name() {
-				err := r.PowerLibrary.GetSharedPool().SetPowerProfile(nil)
-				if err != nil {
-					logger.Error(err, "error setting nil profile")
-					return ctrl.Result{}, err
-				}
-				pool := r.PowerLibrary.GetExclusivePool(req.Name)
-				if pool == nil {
-					notFoundErr := fmt.Errorf("pool not found")
-					logger.Error(notFoundErr, fmt.Sprintf("attempted to remove the non existing pool %s", req.Name))
-					return ctrl.Result{}, notFoundErr
-				}
-				err = pool.Remove()
-				if err != nil {
-					logger.Error(err, "error deleting the power profile from the library")
-					return ctrl.Result{}, err
-				}
-
-				// Remove the profile from PowerNodeState.
-				err = removePowerNodeStatusProfileEntry(ctx, r.Client, nodeName, req.Name, &logger)
-				if err != nil {
-					logger.Error(err, "error removing profile from PowerNodeState")
-					// Pool was already removed, but requeue to retry the status cleanup.
-					return ctrl.Result{RequeueAfter: queuetime}, nil
-				}
-
-				return ctrl.Result{}, nil
-			}
-
-			// Remove the extended resources for this power profile from the node.
-			err = r.removeExtendedResources(ctx, nodeName, req.NamespacedName.Name, &logger)
-			if err != nil {
-				logger.Error(err, "error removing the extended resources from the node")
-				return ctrl.Result{}, err
-			}
-
-			// Remove the profile from PowerNodeState.
-			err = removePowerNodeStatusProfileEntry(ctx, r.Client, nodeName, req.NamespacedName.Name, &logger)
-			if err != nil {
-				logger.Error(err, "error removing profile from PowerNodeState")
-				// Extended resources were already cleaned up, but requeue to retry the status cleanup.
-				return ctrl.Result{RequeueAfter: queuetime}, nil
-			}
-
-			return ctrl.Result{}, nil
+			return r.handleProfileDeletion(ctx, req, nodeName, &logger)
 		}
 
 		// Requeue the request.
@@ -277,6 +228,57 @@ func (r *PowerProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// If the workload already exists then the power profile was just updated and the power library will take care of reconfiguring cores
+	return ctrl.Result{}, nil
+}
+
+// handleProfileDeletion cleans up when a PowerProfile CR is deleted. It removes the profile from the
+// power library (which moves cores back to the shared pool), deletes extended resources from the node,
+// and removes the profile entry from PowerNodeState.
+func (r *PowerProfileReconciler) handleProfileDeletion(ctx context.Context, req ctrl.Request, nodeName string, logger *logr.Logger) (ctrl.Result, error) {
+	// If this profile was used by the shared pool, clear the shared pool profile and remove the exclusive pool.
+	if r.PowerLibrary.GetSharedPool().GetPowerProfile() != nil && req.Name == r.PowerLibrary.GetSharedPool().GetPowerProfile().Name() {
+		err := r.PowerLibrary.GetSharedPool().SetPowerProfile(nil)
+		if err != nil {
+			logger.Error(err, "error setting nil profile")
+			return ctrl.Result{}, err
+		}
+		pool := r.PowerLibrary.GetExclusivePool(req.Name)
+		if pool == nil {
+			notFoundErr := fmt.Errorf("pool not found")
+			logger.Error(notFoundErr, fmt.Sprintf("attempted to remove the non existing pool %s", req.Name))
+			return ctrl.Result{}, notFoundErr
+		}
+		err = pool.Remove()
+		if err != nil {
+			logger.Error(err, "error deleting the power profile from the library")
+			return ctrl.Result{}, err
+		}
+
+		// Remove the profile from PowerNodeState.
+		err = removePowerNodeStatusProfileEntry(ctx, r.Client, nodeName, req.Name, logger)
+		if err != nil {
+			logger.Error(err, "error removing profile from PowerNodeState")
+			return ctrl.Result{RequeueAfter: queuetime}, nil
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Remove the extended resources for this power profile from the node.
+	err := r.removeExtendedResources(ctx, nodeName, req.NamespacedName.Name, logger)
+	if err != nil {
+		logger.Error(err, "error removing the extended resources from the node")
+		return ctrl.Result{}, err
+	}
+
+	// Remove the profile from PowerNodeState.
+	err = removePowerNodeStatusProfileEntry(ctx, r.Client, nodeName, req.NamespacedName.Name, logger)
+	if err != nil {
+		logger.Error(err, "error removing profile from PowerNodeState")
+		// Extended resources were already cleaned up, but requeue to retry the status cleanup.
+		return ctrl.Result{RequeueAfter: queuetime}, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
Extract handlePodDeletion from PowerPodReconciler.Reconcile and handleProfileDeletion from PowerProfileReconciler.Reconcile to bring both functions under the gocyclo threshold (30).

No logic changes — pure mechanical extraction of self-contained deletion paths into helper methods.

Tested on k8s.