### PR TITLE
fix: Add Multus CNI bypass annotation to node agent DaemonSet

### DIFF
--- a/build/manifests/power-node-agent-ds.yaml
+++ b/build/manifests/power-node-agent-ds.yaml
@@ -12,6 +12,8 @@ spec:
       namespace: power-manager
       labels:
         name: power-node-agent-pod
+      annotations:
+        k8s.v1.cni.cncf.io/networks: "[]"
     spec:
       serviceAccountName: power-manager-node-agent
       tolerations:


### PR DESCRIPTION
## Summary
- Add `k8s.v1.cni.cncf.io/networks: "[]"` annotation to power-node-agent DaemonSet template

## Problem
Without this annotation, Multus CNI attempts to query the Kubernetes API for NetworkAttachmentDefinition resources during pod creation. On nodes where API queries experience timeouts, this causes pod creation to fail with:
```
Failed to create pod sandbox: plugin type="multus" failed: error waiting for pod: 
Get "https://10.96.0.1:443/api/v1/namespaces/power-manager/pods/...": context deadline exceeded
```

## Solution
The annotation explicitly tells Multus to skip querying for additional network attachments, allowing the pod to start with only the default network. The power-node-agent only requires the default network and does not need additional SR-IOV or custom network attachments.

## Impact
- Resolves pod creation timeouts on nodes with Multus CNI
- Prevents DaemonSet pods from remaining in ContainerCreating state indefinitely
- No functional impact since the agent doesn't require additional network attachments

## Test plan
- [x] Deployed on cluster with Multus CNI
- [x] Verified power-node-agent pods start successfully on all nodes
- [x] Confirmed pods use only default Flannel network

🤖 Generated with [Claude Code](https://claude.com/claude-code)